### PR TITLE
Fix extractDiceFromMoves duplicate filtering bug for doubles (#43)

### DIFF
--- a/src/moveSelection.ts
+++ b/src/moveSelection.ts
@@ -185,11 +185,12 @@ function getBestStrategicMove(
 
 /**
  * Extract dice values from the available moves
+ * Note: For doubles (e.g., [3,3]), this will return [3,3,3,3] as expected
  */
 function extractDiceFromMoves(readyMoves: BackgammonMoveReady[]): number[] {
   const diceValues: number[] = []
   for (const move of readyMoves) {
-    if (move.dieValue && !diceValues.includes(move.dieValue)) {
+    if (move.dieValue) {
       diceValues.push(move.dieValue)
     }
   }


### PR DESCRIPTION
## Summary
Fixes critical bug in AI package where  incorrectly filtered duplicate die values, breaking doubles handling for robots.

## Problem
The function used  to filter duplicates, causing:
- For [3,3] roll with 4 moves: returned  instead of 
- Opening book failures (expects correct dice count)
- Strategic heuristics failures
- Robots getting stuck on doubles

## Solution
Removed the duplicate filtering since legitimate doubles should have multiple moves with the same die value.

## Code Changes


## Testing
- Verified the fix preserves correct dice extraction for both regular and doubles rolls
- No breaking changes to existing functionality

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)