### PR TITLE
fix(ai): implement true one-shot planning to fix die-tracking bug (#250)

### DIFF
--- a/src/robotExecution.ts
+++ b/src/robotExecution.ts
@@ -191,11 +191,10 @@ export const executeRobotTurnWithGNU = async (
   // One-shot plan: ask GNU once for the full sequence and execute without re-asking mid-turn
   const startMoves = (workingGame.activePlay?.moves || []) as any[]
   const startReady = startMoves.filter((m) => m.stateKind === 'ready')
-  let roll: BackgammonRoll
-  let rollSource: 'ready-derived' = 'ready-derived'
+  const rollSource: 'one-shot' = 'one-shot'
   const d1 = (startReady[0]?.dieValue ?? 1) as BackgammonDieValue
   const d2 = (startReady[1]?.dieValue ?? d1) as BackgammonDieValue
-  roll = [d1, d2]
+  const roll: BackgammonRoll = [d1, d2]
 
   const exportToGnuPositionId = await getExportToGnuPositionId()
 
@@ -243,6 +242,16 @@ export const executeRobotTurnWithGNU = async (
     return hint?.moves || []
   }
 
+  // Get plan ONCE before the loop (true one-shot planning to avoid die-tracking bug #250)
+  let plan: MoveStep[] = []
+  try {
+    plan = await getPlanForGame(workingGame, roll)
+  } catch (err) {
+    throw new Error(`[AI] Failed to get GNU hints: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  let planIdx = 0
+  const planLength = plan.length
+
   while (guard-- > 0 && workingGame.stateKind === 'moving') {
     const moves = (workingGame.activePlay?.moves || []) as any[]
     const ready = moves.filter((m) => m.stateKind === 'ready')
@@ -252,23 +261,6 @@ export const executeRobotTurnWithGNU = async (
       workingGame = CoreUtil.Game.checkAndCompleteTurn(workingGame)
       break
     }
-
-    // Refresh roll and plan per step to avoid stale sequences
-    if (ready.length > 0) {
-      const d1 = (ready[0]?.dieValue ?? 1) as BackgammonDieValue
-      const d2 = (ready[1]?.dieValue ?? d1) as BackgammonDieValue
-      roll = [d1, d2]
-      rollSource = 'ready-derived'
-    }
-
-    let plan: MoveStep[] = []
-    try {
-      plan = await getPlanForGame(workingGame, roll)
-    } catch (err) {
-      throw new Error(`[AI] Failed to get GNU hints: ${err instanceof Error ? err.message : String(err)}`)
-    }
-    const planIdx = 0
-    const planLength = plan.length
 
     // Next planned step (if any)
     const positionId = workingGame.gnuPositionId
@@ -541,7 +533,7 @@ export const executeRobotTurnWithGNU = async (
       singleDieRemaining: ready.length === 1,
       planLength,
       planIndex: planIdx,
-      planSource: 'turn-plan',
+      planSource: 'one-shot',
       hintCount: planLength > 0 ? 1 : 0,
       mappedOriginId,
       usedFallback: false,
@@ -561,7 +553,7 @@ export const executeRobotTurnWithGNU = async (
       offCount: offCnt2,
       readyMovesSample: sample2,
     })
-    logger.info('[AI] Step executed (step-plan)', {
+    logger.info('[AI] Step executed (one-shot)', {
       positionId,
       roll,
       planLength,
@@ -570,8 +562,9 @@ export const executeRobotTurnWithGNU = async (
       postState: workingGame.stateKind,
     })
 
+    // Advance to next step in plan after successful execution
     if (stepFromPlan) {
-      // plan is recomputed each step, so planIdx is always 0
+      planIdx++
     }
     if (workingGame.stateKind === 'completed') break
   }


### PR DESCRIPTION
## Summary
- Move GNU plan retrieval **before** the while loop (true one-shot planning)
- Remove redundant roll re-derivation and re-planning inside the loop
- Track `planIdx` and increment after each successful step
- Update telemetry to use 'one-shot' labels for clarity

## Problem
The robot was re-querying GNU mid-turn. When the code re-derived the remaining dice and re-planned:
1. Robot rolls [3, 5]
2. GNU returns plan: move A (use die 3), move B (use die 5)
3. Robot executes move A (die 3 consumed)
4. Code re-queries GNU with dice derived from ready moves
5. GNU returns NEW plan based on current position
6. New plan's first move may suggest using die 3 again
7. Error: "Die value 3 has already been used"

## Solution
Cache the original plan once at turn start and execute steps sequentially by incrementing a plan index. Never re-plan mid-turn.

## Test Results
- **Before fix:** Games failed with "Die value X has already been used" error
- **After fix:** Zero occurrences of die-tracking error
- Remaining failures are from coordinate mismatch issue (#247), which is a separate bug

## Dependencies
Requires types PR: https://github.com/nodots/nodots-backgammon-types/pull/50

## Test plan
- [x] AI package builds successfully
- [x] Ran robot failure capture script - zero die-tracking errors

Closes nodots/nodots-backgammon#250

🤖 Generated with [Claude Code](https://claude.ai/code)