### PR TITLE
feat: split GNU and Nodots AI into separate providers

### DIFF
--- a/src/GNUAIProvider.ts
+++ b/src/GNUAIProvider.ts
@@ -1,9 +1,8 @@
 /**
  * GNU Backgammon AI Provider
  *
- * Implements the RobotAIProvider interface using GNU Backgammon's
- * world-class analysis engine for gbg-bot, and the nodots heuristic
- * model (opening book + strategic heuristics) for all other robots.
+ * Handles all GNU-based robots using the native gnubg-hints addon.
+ * Registered for gnu-* and gbg-bot email patterns.
  */
 
 import type {
@@ -15,35 +14,7 @@ import type {
 import type { RobotAIProvider } from '@nodots-llc/backgammon-core'
 import { executeRobotTurnWithGNU } from './robotExecution.js'
 
-// Known gbg-bot user IDs (must match moveSelection.ts)
-const KNOWN_GBG_BOT_IDS = new Set<string>([
-  'da7eac85-cf8f-49f4-b97d-9f40d3171b36',
-])
-
-function isGbgBot(userId?: string): boolean {
-  return !!userId && KNOWN_GBG_BOT_IDS.has(userId)
-}
-
-/**
- * GNUAIProvider
- *
- * Routes robot turn execution based on robot identity:
- * - gbg-bot: GNU Backgammon neural network evaluation
- * - All others: nodots heuristic model (opening book + strategic heuristics)
- *
- * @example
- * ```typescript
- * import { RobotAIRegistry } from '@nodots-llc/backgammon-core'
- * import { GNUAIProvider } from '@nodots-llc/backgammon-ai'
- *
- * RobotAIRegistry.register(new GNUAIProvider())
- * ```
- */
 export class GNUAIProvider implements RobotAIProvider {
-  /**
-   * Execute a complete robot turn.
-   * gbg-bot uses GNU Backgammon hints; all other robots use heuristic selection.
-   */
   async executeRobotTurn(
     game: BackgammonGameMoving
   ): Promise<BackgammonGameRolling> {
@@ -52,80 +23,14 @@ export class GNUAIProvider implements RobotAIProvider {
         `GNUAIProvider requires active player to be a robot, but got isRobot=${game.activePlayer.isRobot}`
       )
     }
-
-    const userId = (game.activePlayer as any).userId as string | undefined
-
-    if (isGbgBot(userId)) {
-      return executeRobotTurnWithGNU(game)
-    }
-
-    // Non-gbg robots: use selectBestMove (nodots heuristic) iteratively
-    return this.executeRobotTurnWithHeuristic(game)
-  }
-
-  /**
-   * Execute a full robot turn using selectBestMove in a loop.
-   * Each iteration picks the best heuristic move and executes it
-   * via Game.executeAndRecalculate until no ready moves remain.
-   */
-  private async executeRobotTurnWithHeuristic(
-    game: BackgammonGameMoving
-  ): Promise<BackgammonGameRolling> {
-    // Lazy import to avoid circular dependency
-    const Core = await import('@nodots-llc/backgammon-core')
-    const { selectBestMove } = await import('./moveSelection.js')
-
-    let workingGame: any = game
-    let guard = 8
-
-    while (guard-- > 0 && workingGame.stateKind === 'moving') {
-      const moves = (workingGame.activePlay?.moves || []) as any[]
-      const ready = moves.filter((m: any) => m.stateKind === 'ready')
-
-      if (ready.length === 0) {
-        workingGame = Core.Game.checkAndCompleteTurn(workingGame)
-        break
-      }
-
-      // Use the nodots heuristic to select the best move
-      const play = workingGame.activePlay
-      const userId = (workingGame.activePlayer as any)?.userId
-      const bestMove = await selectBestMove(play, userId)
-
-      if (!bestMove) {
-        workingGame = Core.Game.checkAndCompleteTurn(workingGame)
-        break
-      }
-
-      // Find the origin container ID from the selected move's possibleMoves
-      const possibleMoves = bestMove.possibleMoves || []
-      const firstPossible = possibleMoves[0]
-      const originId = firstPossible?.origin?.id
-
-      if (!originId) {
-        workingGame = Core.Game.checkAndCompleteTurn(workingGame)
-        break
-      }
-
-      workingGame = Core.Game.executeAndRecalculate(workingGame, originId)
-
-      if (workingGame.stateKind === 'completed') break
-    }
-
-    // Transition from 'moved' to 'rolling' for the next player
-    if (workingGame.stateKind === 'moved') {
-      const Core = await import('@nodots-llc/backgammon-core')
-      workingGame = Core.Game.handleRobotMovedState(workingGame)
-    }
-
-    return workingGame as BackgammonGameRolling
+    return executeRobotTurnWithGNU(game)
   }
 
   async selectBestMove(
     play: BackgammonPlayMoving,
-    playerUserId?: string
+    _playerUserId?: string
   ): Promise<BackgammonMoveReady | undefined> {
     const { selectBestMove } = await import('./moveSelection.js')
-    return selectBestMove(play, playerUserId)
+    return selectBestMove(play)
   }
 }

--- a/src/NodotsAIProvider.ts
+++ b/src/NodotsAIProvider.ts
@@ -1,0 +1,77 @@
+/**
+ * Nodots AI Provider
+ *
+ * Handles non-GNU robots using opening book + strategic heuristics.
+ * Registered for nbg-bot and as the fallback provider.
+ */
+
+import type {
+  BackgammonGameMoving,
+  BackgammonGameRolling,
+  BackgammonPlayMoving,
+  BackgammonMoveReady,
+} from '@nodots-llc/backgammon-types'
+import type { RobotAIProvider } from '@nodots-llc/backgammon-core'
+
+export class NodotsAIProvider implements RobotAIProvider {
+  async executeRobotTurn(
+    game: BackgammonGameMoving
+  ): Promise<BackgammonGameRolling> {
+    if (!game.activePlayer.isRobot) {
+      throw new Error(
+        `NodotsAIProvider requires active player to be a robot, but got isRobot=${game.activePlayer.isRobot}`
+      )
+    }
+
+    const Core = await import('@nodots-llc/backgammon-core')
+    const { selectBestMove } = await import('./moveSelection.js')
+
+    let workingGame: any = game
+    let guard = 8
+
+    while (guard-- > 0 && workingGame.stateKind === 'moving') {
+      const moves = (workingGame.activePlay?.moves || []) as any[]
+      const ready = moves.filter((m: any) => m.stateKind === 'ready')
+
+      if (ready.length === 0) {
+        workingGame = Core.Game.checkAndCompleteTurn(workingGame)
+        break
+      }
+
+      const play = workingGame.activePlay
+      const bestMove = await selectBestMove(play)
+
+      if (!bestMove) {
+        workingGame = Core.Game.checkAndCompleteTurn(workingGame)
+        break
+      }
+
+      const possibleMoves = bestMove.possibleMoves || []
+      const firstPossible = possibleMoves[0]
+      const originId = firstPossible?.origin?.id
+
+      if (!originId) {
+        workingGame = Core.Game.checkAndCompleteTurn(workingGame)
+        break
+      }
+
+      workingGame = Core.Game.executeAndRecalculate(workingGame, originId)
+
+      if (workingGame.stateKind === 'completed') break
+    }
+
+    if (workingGame.stateKind === 'moved') {
+      workingGame = Core.Game.handleRobotMovedState(workingGame)
+    }
+
+    return workingGame as BackgammonGameRolling
+  }
+
+  async selectBestMove(
+    play: BackgammonPlayMoving,
+    _playerUserId?: string
+  ): Promise<BackgammonMoveReady | undefined> {
+    const { selectBestMove } = await import('./moveSelection.js')
+    return selectBestMove(play)
+  }
+}

--- a/src/__tests__/gbg-bot-failure.test.ts
+++ b/src/__tests__/gbg-bot-failure.test.ts
@@ -1,5 +1,6 @@
 /**
- * Test that gbg-bot fails appropriately when GNU BG is unavailable
+ * Test that selectBestMove works as a heuristic selector
+ * (GNU routing is now handled by the plugin registry, not selectBestMove)
  */
 
 import type {
@@ -9,11 +10,9 @@ import type {
   BackgammonBoard,
 } from '@nodots-llc/backgammon-types'
 import { jest } from '@jest/globals'
-import { gnubgHints } from '../gnubg'
 import { selectBestMove } from '../moveSelection'
 
-const createMockPlay = (options?: { userId?: string; isRobot?: boolean }): BackgammonPlayMoving => {
-  const { userId = 'player-1', isRobot = true } = options ?? {}
+const createMockPlay = (): BackgammonPlayMoving => {
   const points = Array.from({ length: 24 }, (_, index) => ({
     id: `pt-${index + 1}`,
     kind: 'point' as const,
@@ -63,7 +62,7 @@ const createMockPlay = (options?: { userId?: string; isRobot?: boolean }): Backg
 
   const player = {
     id: 'player-1',
-    userId,
+    userId: 'test-user',
     color: 'white' as const,
     direction: 'clockwise' as const,
     stateKind: 'moving' as const,
@@ -75,7 +74,7 @@ const createMockPlay = (options?: { userId?: string; isRobot?: boolean }): Backg
       total: 5,
     },
     pipCount: 150,
-    isRobot,
+    isRobot: true,
     rollForStartValue: 3 as any,
   }
 
@@ -101,68 +100,23 @@ const createMockPlay = (options?: { userId?: string; isRobot?: boolean }): Backg
     id: 'play-1',
     stateKind: 'moving',
     player,
-    moves: new Set([move]) as any,
+    moves: [move],
     board,
   } as unknown as BackgammonPlayMoving
 }
 
-describe('gbg-bot GNU BG requirement', () => {
-  const gbgPlay = createMockPlay({
-    userId: 'da7eac85-cf8f-49f4-b97d-9f40d3171b36',
-    isRobot: true,
-  })
-  const nodotsPlay = createMockPlay({
-    userId: 'nbg-bot-user',
-    isRobot: true,
-  })
-
-  it('should fail when gbg-bot cannot access GNU Backgammon and log AI engine', async () => {
-    // Spy on logger to verify AI engine is logged (logger.info uses console.info)
-    const loggerInfoSpy = jest.spyOn(console, 'info').mockImplementation()
-    const loggerErrorSpy = jest.spyOn(console, 'error').mockImplementation()
-
-    jest.spyOn(gnubgHints, 'getMoveHints').mockImplementationOnce(() => {
-      throw new Error('Native addon unavailable')
-    })
-
-    await expect(selectBestMove(gbgPlay, 'gbg-bot')).rejects.toThrow(
-      /gbg-bot requires GNU Backgammon hints but the integration failed/i,
-    )
-
-    // Verify that the AI engine and failure were logged
-    expect(loggerInfoSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[INFO] [AI] gbg-bot starting move selection')
-    )
-    expect(loggerErrorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[ERROR] [AI] gbg-bot GNU Backgammon integration error')
-    )
-
-    loggerInfoSpy.mockRestore()
-    loggerErrorSpy.mockRestore()
-  })
-
-  it('should allow other bots to use fallback logic and log AI engine', async () => {
-    // Spy on logger to verify AI engine is logged (logger.info uses console.info)
-    const loggerSpy = jest.spyOn(console, 'info').mockImplementation()
-
-    const result = await selectBestMove(nodotsPlay, 'nbg-bot-v1')
+describe('selectBestMove heuristic selection', () => {
+  it('should select a ready move using heuristics', async () => {
+    const play = createMockPlay()
+    const result = await selectBestMove(play)
     expect(result).toBeDefined()
     expect(result?.stateKind).toBe('ready')
-
-    // Verify that the AI engine was logged
-    expect(loggerSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[INFO] [AI] nbg-bot-v1 AI Engine: Nodots AI (GNU BG excluded)')
-    )
-    expect(loggerSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[INFO] [AI] nbg-bot-v1 Move selected via: Strategic Heuristics')
-    )
-
-    loggerSpy.mockRestore()
   })
 
-  it('should work without player nickname (for backward compatibility)', async () => {
-    const result = await selectBestMove(nodotsPlay)
-    expect(result).toBeDefined()
-    expect(result?.stateKind).toBe('ready')
+  it('should return undefined for empty moves', async () => {
+    const play = createMockPlay()
+    play.moves = [] as any
+    const result = await selectBestMove(play)
+    expect(result).toBeUndefined()
   })
 })

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -5,40 +5,10 @@ import type {
   BackgammonPoint,
   BackgammonPoints,
 } from '@nodots-llc/backgammon-types';
-import { jest } from '@jest/globals';
-import type { MoveHint } from '@nodots-llc/gnubg-hints';
-
-let mockHints: MoveHint[] = []
-const initializeMock = jest.fn().mockResolvedValue(undefined)
-const getMoveHintsMock = jest.fn(async () => mockHints)
-
-jest.unstable_mockModule('@nodots-llc/gnubg-hints', () => ({
-  GnuBgHints: {
-    initialize: initializeMock,
-    configure: jest.fn(),
-    getMoveHints: getMoveHintsMock,
-    getDoubleHint: jest.fn(),
-    getTakeHint: jest.fn(),
-    shutdown: jest.fn(),
-  },
-  createHintRequestFromGame: () => ({
-    board: { points: [], bar: {}, off: {} },
-    dice: [0, 0],
-    activePlayerColor: 'white',
-    activePlayerDirection: 'clockwise',
-    cubeValue: 1,
-    cubeOwner: null,
-    matchScore: [0, 0],
-    matchLength: 0,
-    crawford: false,
-    jacoby: false,
-    beavers: false,
-  }),
-}))
 
 const { selectBestMove } = await import('../moveSelection.js')
 
-describe('selectBestMove with GNU hints', () => {
+describe('selectBestMove heuristic selection', () => {
   function createTestPlay(): BackgammonPlayMoving {
     const points = Array.from({ length: 24 }, (_, index) => ({
       id: `pt-${index + 1}`,
@@ -89,7 +59,7 @@ describe('selectBestMove with GNU hints', () => {
 
     const player = {
       id: 'player-1',
-      userId: 'da7eac85-cf8f-49f4-b97d-9f40d3171b36',
+      userId: 'test-robot',
       color: 'white' as const,
       direction: 'clockwise' as const,
       stateKind: 'moving' as const,
@@ -123,49 +93,26 @@ describe('selectBestMove with GNU hints', () => {
       ],
     } as BackgammonMoveReady;
 
-    const moves = new Set<BackgammonMoveReady>([move]) as any;
-
     return {
       id: 'play-1',
       stateKind: 'moving',
       player,
       board,
-      moves,
+      moves: [move],
     } as unknown as BackgammonPlayMoving;
   }
 
-  it('selects the move suggested by the highest ranked hint', async () => {
+  it('selects a ready move via heuristics', async () => {
     const play = createTestPlay();
-
-    mockHints = [
-      {
-        rank: 1,
-        difference: 0,
-        equity: 0.42,
-        evaluation: {
-          win: 0.6,
-          winGammon: 0.1,
-          winBackgammon: 0.01,
-          loseGammon: 0.05,
-          loseBackgammon: 0.005,
-          equity: 0.42,
-          cubefulEquity: 0.42,
-        },
-        moves: [
-          {
-            from: 13,
-            to: 8,
-            moveKind: 'point-to-point',
-            isHit: false,
-            player: 'white',
-            fromContainer: 'point',
-            toContainer: 'point',
-          },
-        ],
-      },
-    ];
-
-    const result = await selectBestMove(play, 'gbg-bot');
+    const result = await selectBestMove(play);
     expect(result?.id).toBe('move-1');
+    expect(result?.stateKind).toBe('ready');
+  });
+
+  it('returns undefined for empty moves array', async () => {
+    const play = createTestPlay();
+    (play as any).moves = [];
+    const result = await selectBestMove(play);
+    expect(result).toBeUndefined();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,3 @@
-// Node version check - MUST be first, before any imports that trigger native addon loading
-const REQUIRED_NODE_MAJOR = 20;
-const currentMajor = parseInt(process.versions.node.split('.')[0], 10);
-if (currentMajor !== REQUIRED_NODE_MAJOR) {
-  console.error('\x1b[31m%s\x1b[0m', '╔═══════════════════════════════════════════════════════════════╗');
-  console.error('\x1b[31m%s\x1b[0m', '║  FATAL: Wrong Node.js version                                 ║');
-  console.error('\x1b[31m%s\x1b[0m', '╠═══════════════════════════════════════════════════════════════╣');
-  console.error('\x1b[31m%s\x1b[0m', `║  Required: Node.js ${REQUIRED_NODE_MAJOR}.x                                        ║`);
-  console.error('\x1b[31m%s\x1b[0m', `║  Current:  Node.js ${process.versions.node.padEnd(20)}                    ║`);
-  console.error('\x1b[31m%s\x1b[0m', '╠═══════════════════════════════════════════════════════════════╣');
-  console.error('\x1b[31m%s\x1b[0m', '║  The gnubg-hints native addon requires Node.js 20.            ║');
-  console.error('\x1b[31m%s\x1b[0m', '║  Fix: Run `nvm use 20` then try again.                        ║');
-  console.error('\x1b[31m%s\x1b[0m', '╚═══════════════════════════════════════════════════════════════╝');
-  process.exit(1);
-}
-
 import type { BackgammonMoveBase } from '@nodots-llc/backgammon-types';
 import type {
   DoubleHint,
@@ -33,18 +17,27 @@ let registered = false;
 export async function registerAIProvider(): Promise<void> {
   if (registered) return;
 
-  // Dynamic imports to break circular dependency (ESM-compatible)
   const { RobotAIRegistry } = await import('@nodots-llc/backgammon-core');
   const { GNUAIProvider } = await import('./GNUAIProvider.js');
+  const { NodotsAIProvider } = await import('./NodotsAIProvider.js');
 
-  RobotAIRegistry.register(new GNUAIProvider());
-  // Initialize and configure GNU hints once so execution and analysis share identical settings
+  const gnuProvider = new GNUAIProvider();
+  const nodotsProvider = new NodotsAIProvider();
+
+  // GNU robots: matched by email prefix from seed-robots.ts
+  RobotAIRegistry.register('gnu-*', gnuProvider);
+  RobotAIRegistry.register('gbg-bot@nodots.com', gnuProvider);
+  // Nodots heuristic bot
+  RobotAIRegistry.register('nbg-*', nodotsProvider);
+  // Fallback for any unrecognized robot
+  RobotAIRegistry.register('*', nodotsProvider);
+
+  // Initialize GNU hints engine
   try {
     await initializeGnubgHints({
       config: DEFAULT_HINTS_CONFIG,
     });
   } catch (err) {
-    // Non-fatal: consumers may initialize separately; log for visibility
     console.warn('[AI] gnubg-hints init/config skipped:', String(err));
   }
   registered = true;
@@ -117,6 +110,7 @@ export * from './hintContext.js';
 
 // Export AI provider implementations
 export { GNUAIProvider } from './GNUAIProvider.js';
+export { NodotsAIProvider } from './NodotsAIProvider.js';
 export { executeRobotTurnWithGNU } from './robotExecution.js';
 
 // Export luck analysis

--- a/src/moveSelection.ts
+++ b/src/moveSelection.ts
@@ -6,24 +6,14 @@
 import type {
   BackgammonPlayMoving,
   BackgammonMoveReady,
-  BackgammonCheckerContainer,
   BackgammonMoveDirection,
 } from '@nodots-llc/backgammon-types';
-import type { MoveHint, MoveStep } from '@nodots-llc/gnubg-hints';
 import type { GnubgColor } from './hintContext.js';
-import {
-  buildHintContextFromPlay,
-  getContainerKind,
-  getNormalizedPosition,
-} from './hintContext.js';
+import { getNormalizedPosition } from './hintContext.js';
 
-// Map direction to GnubgColor for getNormalizedPosition, which reads
-// position.clockwise when color is 'white' and position.counterclockwise
-// when color is 'black'.
 function directionToGnuColor(dir: BackgammonMoveDirection): GnubgColor {
   return dir === 'clockwise' ? 'white' : 'black';
 }
-import { gnubgHints } from './gnubg.js';
 // Optional policy model support (not required for baseline build)
 let selectMoveWithPolicy: ((play: BackgammonPlayMoving, model: any) => BackgammonMoveReady | undefined) | null = null
 async function tryLoadPolicyModel() {
@@ -54,15 +44,12 @@ const logger = {
 }
 
 /**
- * Main AI move selection function that tries multiple strategies in order:
- * 1. GNU Backgammon AI (required for gbg-bot, optional for others)
- * 2. Opening book for common opening rolls
- * 3. Strategic heuristics
- * 4. Random selection (fallback)
+ * Heuristic move selection: opening book -> trained policy -> strategic heuristics.
+ * Used by NodotsAIProvider. GNU routing is handled by the plugin registry,
+ * not by this function.
  */
 export async function selectBestMove(
   play: BackgammonPlayMoving,
-  playerNickname?: string
 ): Promise<BackgammonMoveReady | undefined> {
   const movesArray = Array.isArray(play.moves)
     ? play.moves
@@ -72,120 +59,32 @@ export async function selectBestMove(
   const readyMoves = (movesArray as BackgammonMoveReady[]).filter(
     (move): move is BackgammonMoveReady => move.stateKind === 'ready'
   )
-  
+
   if (readyMoves.length === 0) return undefined
 
-  // Determine identity. For now, only two robots exist: gbg-bot and nbg-bot-v1.
-  // Core currently passes userId here, not nickname. Hardcode detection by name or id.
-  const passedIdentifier = playerNickname || ''
-  const playerUserId = (play as any)?.player?.userId as string | undefined
-  const isRobot = !!(play as any)?.player?.isRobot
-
-  // Known mapping (hardcoded for current system):
-  // gbg-bot userId observed in logs/tests: da7eac85-cf8f-49f4-b97d-9f40d3171b36
-  const KNOWN_GBG_BOT_IDS = new Set<string>([
-    'da7eac85-cf8f-49f4-b97d-9f40d3171b36',
-  ])
-
-  const isGbgBot =
-    passedIdentifier === 'gbg-bot' ||
-    (playerUserId ? KNOWN_GBG_BOT_IDS.has(playerUserId) : false)
-
-  // With only two robots in the system, treat any other robot as nbg-bot-v1
-  const isNbgBot =
-    passedIdentifier === 'nbg-bot-v1' || (isRobot && !isGbgBot)
-
-  // Use a friendly name in logs
-  const robotName = isGbgBot ? 'gbg-bot' : isNbgBot ? 'nbg-bot-v1' : (passedIdentifier || playerUserId || 'Unknown Robot')
+  const robotName = 'Nodots AI'
   logger.info(`[AI] ${robotName} starting move selection with ${readyMoves.length} available moves`)
 
-  if (isGbgBot) {
-    logger.info(`[AI] ${robotName} AI Engine: GNU Backgammon (required)`);
-
-    const available = await gnubgHints.isAvailable();
-    if (!available) {
-      const instructions = gnubgHints.getBuildInstructions();
-      logger.error(
-        `[AI] ${robotName} GNU Backgammon hints unavailable — terminating turn selection`,
-      );
-      throw new Error(
-        `gbg-bot cannot function without GNU Backgammon hints.\n\n${instructions}`,
-      );
-    }
-
-    try {
-      const { request } = buildHintContextFromPlay(play);
-      logger.debug(
-        `[AI] ${robotName} requesting structured hints from @nodots-llc/gnubg-hints`,
-      );
-      const hints = await gnubgHints.getMoveHints(request, 10);
-
-      if (!Array.isArray(hints) || hints.length === 0) {
-        throw new Error('No move hints returned by @nodots-llc/gnubg-hints');
-      }
-
-      const matched = findMoveMatchingHints(readyMoves, hints, robotName);
-
-      if (matched) {
-        const { move, hint } = matched;
-        logger.info(
-          `[AI] ${robotName} Move selected via: GNU Backgammon Engine (hint rank ${hint.rank})`,
-        );
-        ;(move as any).__source = 'gnu-hint'
-        return move;
-      }
-      const hintSummary = hints
-        .slice(0, 3)
-        .map((hint) =>
-          (hint.moves || [])
-            .map((step) => `${step.from}:${step.to}:${step.fromContainer}->${step.toContainer}`)
-            .join(',')
-        )
-        .filter(Boolean);
-      throw new Error(
-        `GNU Backgammon hints did not match any legal moves for ${robotName} (hintSample=${JSON.stringify(
-          hintSummary
-        )})`,
-      );
-    } catch (error) {
-      logger.error(
-        `[AI] ${robotName} GNU Backgammon integration error: ${String(error)}`,
-      );
-      throw new Error(
-        `gbg-bot requires GNU Backgammon hints but the integration failed: ${error}`,
-      );
-    }
-  }
-
-  if (isNbgBot) {
-    logger.info(`[AI] ${robotName} AI Engine: Nodots AI (GNU BG excluded)`)
-
-    // Try trained policy first if available
-    try {
-      const modelDir = resolveModelDir();
-      const modelPath = modelDir ? path.join(modelDir, 'model.json') : undefined;
-      if (modelPath && fs.existsSync(modelPath)) {
-        const raw = fs.readFileSync(modelPath, 'utf-8');
-        const model = JSON.parse(raw);
-        const policy = await tryLoadPolicyModel()
-        if (policy) {
-          const policyMove = policy(play, model);
-          if (policyMove) {
-            logger.info(`[AI] ${robotName} Move selected via: Trained Policy`);
-            (policyMove as any).__source = 'policy';
-            return policyMove;
-          }
+  // Try trained policy first if available
+  try {
+    const modelDir = resolveModelDir();
+    const modelPath = modelDir ? path.join(modelDir, 'model.json') : undefined;
+    if (modelPath && fs.existsSync(modelPath)) {
+      const raw = fs.readFileSync(modelPath, 'utf-8');
+      const model = JSON.parse(raw);
+      const policy = await tryLoadPolicyModel()
+      if (policy) {
+        const policyMove = policy(play, model);
+        if (policyMove) {
+          logger.info(`[AI] ${robotName} Move selected via: Trained Policy`);
+          (policyMove as any).__source = 'policy';
+          return policyMove;
         }
-        logger.warn(`[AI] ${robotName} Policy available but no move matched; falling back`);
-      } else {
-        logger.debug(`[AI] ${robotName} No trained policy found (searched: ${modelPath || 'n/a'})`);
       }
-    } catch (err) {
-      logger.warn(`[AI] ${robotName} Policy load error: ${String(err)} (falling back)`);
+      logger.warn(`[AI] ${robotName} Policy available but no move matched; falling back`);
     }
-  } else {
-    // For other bots (not gbg-bot, not nbg-bot), indicate they use hybrid AI approach
-    logger.info(`[AI] ${robotName} AI Engine: Hybrid (Opening Book + Strategic Heuristics)`)
+  } catch (err) {
+    logger.warn(`[AI] ${robotName} Policy load error: ${String(err)} (falling back)`);
   }
 
   // Try opening book for opening positions
@@ -321,114 +220,6 @@ function extractDiceFromMoves(readyMoves: BackgammonMoveReady[]): number[] {
     }
   }
   return diceValues
-}
-
-/**
- * Extract position number from a checker container
- */
-function getPositionNumber(container: BackgammonCheckerContainer): number | null {
-  if (container.kind === 'point' && container.position && typeof container.position === 'object') {
-    // Type guard to check if it's a point position object
-    const position = container.position as any
-    if (position.clockwise !== undefined || position.counterclockwise !== undefined) {
-      // Use clockwise position as reference for now, fallback to counterclockwise
-      return position.clockwise || position.counterclockwise || null
-    }
-  }
-  return null
-}
-
-/**
- * Generate GNU Backgammon position ID from current play state
- * This creates a simplified position ID for GNU BG analysis
- */
-interface NormalizedMoveStep {
-  from: number;
-  to: number;
-  fromContainer: MoveStep['fromContainer'];
-  toContainer: MoveStep['toContainer'];
-}
-
-function normalizeMoveSkeleton(
-  move: BackgammonMoveReady,
-  direction: BackgammonMoveDirection,
-): NormalizedMoveStep[] {
-  if (!move.possibleMoves || move.possibleMoves.length === 0) {
-    return [];
-  }
-
-  const steps: NormalizedMoveStep[] = [];
-
-  for (const possibleMove of move.possibleMoves) {
-    const from = getNormalizedPosition(possibleMove.origin, directionToGnuColor(direction));
-    const to = getNormalizedPosition(possibleMove.destination, directionToGnuColor(direction));
-
-    if (from === null || to === null) {
-      continue;
-    }
-
-    steps.push({
-      from,
-      to,
-      fromContainer: getContainerKind(possibleMove.origin),
-      toContainer: getContainerKind(possibleMove.destination),
-    });
-  }
-
-  return steps;
-}
-
-function stepsMatch(hintStep: MoveStep, moveStep: NormalizedMoveStep): boolean {
-  return (
-    hintStep.from === moveStep.from &&
-    hintStep.to === moveStep.to &&
-    hintStep.fromContainer === moveStep.fromContainer &&
-    hintStep.toContainer === moveStep.toContainer
-  );
-}
-
-function findMoveMatchingHints(
-  readyMoves: BackgammonMoveReady[],
-  hints: MoveHint[],
-  robotName: string,
-): { move: BackgammonMoveReady; hint: MoveHint } | undefined {
-  for (const hint of hints) {
-    const targetStep = hint.moves[0];
-    if (!targetStep) {
-      continue;
-    }
-
-    for (const move of readyMoves) {
-      const direction = move.player?.direction as BackgammonMoveDirection | undefined;
-      if (!direction) {
-        continue;
-      }
-
-      const normalizedSteps = normalizeMoveSkeleton(move, direction);
-      const matchingStep = normalizedSteps.find((step) =>
-        stepsMatch(targetStep, step),
-      );
-      if (matchingStep) {
-        logger.debug(
-          `[AI] ${robotName} Matched hint step ${formatHintStep(targetStep)} to move ${formatMoveStep(matchingStep)}`,
-        );
-        return { move, hint };
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function formatHintStep(step: MoveStep): string {
-  return `${step.from}:${step.to}:${step.fromContainer}->${step.toContainer}`;
-}
-
-function formatMoveStep(step: NormalizedMoveStep | undefined): string {
-  if (!step) {
-    return 'unknown-move';
-  }
-  return `${step.from}:${step.to}:${step.fromContainer}->${step.toContainer}`;
 }
 
 function resolveModelDir(): string | undefined {


### PR DESCRIPTION
## Summary
- `GNUAIProvider` now only handles GNU robots (no identity detection)
- `NodotsAIProvider` (new) handles heuristic robots
- Providers registered by email pattern in `registerAIProvider()`
- Removed hardcoded UUID robot identification from `moveSelection.ts`
- Removed Node 20 version gate from `index.ts`
- Cleaned dead GNU-specific code from `moveSelection.ts`

Fixes nodots/nodots-backgammon#287, nodots/nodots-backgammon#288

## Test plan
- [ ] `npm run build` passes
- [ ] GNU robots use `executeRobotTurnWithGNU` (not heuristics)
- [ ] nbg-bot-v1 uses heuristic path
- [ ] No `process.exit(1)` on Node 22