### PR TITLE
fix(ai): refresh possibleMoves from current board before move selection

### DIFF
--- a/src/NodotsAIProvider.ts
+++ b/src/NodotsAIProvider.ts
@@ -30,7 +30,9 @@ export class NodotsAIProvider implements RobotAIProvider {
     let guard = 8
 
     while (guard-- > 0 && workingGame.stateKind === 'moving') {
-      const moves = (workingGame.activePlay?.moves || []) as any[]
+      const moves = Array.isArray(workingGame.activePlay?.moves)
+        ? workingGame.activePlay.moves
+        : Array.from(workingGame.activePlay?.moves ?? [])
       const ready = moves.filter((m: any) => m.stateKind === 'ready')
 
       if (ready.length === 0) {
@@ -38,7 +40,20 @@ export class NodotsAIProvider implements RobotAIProvider {
         break
       }
 
+      // Refresh each ready move's possibleMoves from the CURRENT board.
+      // Stored possibleMoves can be stale after prior moves in the same
+      // turn changed the board. Without this refresh the AI can select
+      // an origin/destination that was valid on a previous board but is
+      // no longer legal, causing CORE to reject with "Invalid move".
       const play = workingGame.activePlay
+      for (const rm of ready) {
+        rm.possibleMoves = Core.Board.getPossibleMoves(
+          workingGame.board,
+          play.player,
+          rm.dieValue
+        )
+      }
+
       const bestMove = await selectBestMove(play)
 
       if (!bestMove) {

--- a/src/robotExecution.ts
+++ b/src/robotExecution.ts
@@ -257,6 +257,18 @@ export const executeRobotTurnWithGNU = async (
       planIdx
     }) + '\n')
 
+    // Refresh possibleMoves for each ready move from the CURRENT board.
+    // Stored possibleMoves can be stale after prior moves in the same
+    // turn changed the board — same fix as NodotsAIProvider.
+    const BoardUtil = await getBoard()
+    for (const rm of ready) {
+      rm.possibleMoves = BoardUtil.getPossibleMoves(
+        workingGame.board,
+        workingGame.activePlay.player,
+        rm.dieValue
+      )
+    }
+
     // If no READY moves remain, let core decide turn completion
     if (ready.length === 0) {
       fs.appendFileSync('/tmp/exec-debug.json', JSON.stringify({ noReadyMoves: true, breakingLoop: true }) + '\n')


### PR DESCRIPTION
## Summary

- Both NodotsAIProvider and GNUAIProvider (robotExecution.ts) were reading stale `possibleMoves` from game state move objects after prior moves in the same multi-die turn changed the board
- CORE's validation recomputes legal moves from the current board and correctly rejected the stale moves, throwing "Invalid move: No legal move from origin X to destination Y with die Z"
- Fix: refresh each ready move's possibleMoves via `Board.getPossibleMoves(currentBoard, player, dieValue)` before selection — same pattern as the working Sim engine

## Test plan

- [x] Human-vs-robot (nbg-bot-v1) e2e spec passes twice in a row (17-29s per game)
- [x] GNU robot-vs-robot API-driven game completes to pip 0/1 (157 iterations, zero errors)