### PR TITLE
test(ai): assert analyzers do not consume dice entropy (Phase 1.2 of nodots/backgammon#327)

### DIFF
--- a/src/__tests__/ai-independence.test.ts
+++ b/src/__tests__/ai-independence.test.ts
@@ -1,0 +1,121 @@
+/**
+ * AI independence — analyzers must not consume dice entropy.
+ *
+ * The invariant:
+ *   Move selection reads the legal-move set and the board; it does not
+ *   roll dice. An analyzer that calls Dice.rollDie during selection
+ *   either (a) peeks at an upcoming opponent roll, or (b) advances the
+ *   RNG in a way that biases subsequent game rolls. Both are regressions
+ *   against the fairness story in Paper 12.
+ *
+ * This test spies on Dice.rollDie from @nodots/backgammon-core and
+ * asserts every shipped analyzer leaves it untouched during selectMove.
+ * The test is deliberately defensive: no current analyzer calls rollDie.
+ * The purpose is to catch the regression at the moment a new analyzer
+ * introduces one.
+ */
+import path from 'path'
+import { jest } from '@jest/globals'
+import { fileURLToPath } from 'url'
+import type { MoveHint } from '@nodots/gnubg-hints'
+
+let mockHints: MoveHint[] = []
+jest.unstable_mockModule('@nodots/gnubg-hints', () => ({
+  GnuBgHints: {
+    initialize: jest.fn().mockResolvedValue(undefined),
+    configure: jest.fn(),
+    getMoveHints: jest.fn(async () => mockHints),
+    getDoubleHint: jest.fn(),
+    getTakeHint: jest.fn(),
+    shutdown: jest.fn(),
+  },
+}))
+
+const { loadAnalyzersFromPluginsDir } = await import('../pluginLoader.js')
+const { Dice } = await import('@nodots/backgammon-core/dist/Dice/index.js')
+
+const moves = [
+  {
+    id: '1',
+    player: {} as any,
+    dieValue: 6,
+    stateKind: 'ready',
+    moveKind: 'point-to-point',
+    origin: { position: { clockwise: 10, counterclockwise: 15 } },
+  },
+  {
+    id: '2',
+    player: {} as any,
+    dieValue: 3,
+    stateKind: 'ready',
+    moveKind: 'point-to-point',
+    origin: { position: { clockwise: 20, counterclockwise: 5 } },
+  },
+  {
+    id: '3',
+    player: {} as any,
+    dieValue: 1,
+    stateKind: 'ready',
+    moveKind: 'point-to-point',
+    origin: { position: { clockwise: 5, counterclockwise: 20 } },
+  },
+]
+
+const hintRequest = {
+  board: { points: [], bar: {}, off: {} } as any,
+  dice: [6, 3] as [number, number],
+  cubeValue: 1,
+  cubeOwner: null,
+  matchScore: [0, 0] as [number, number],
+  matchLength: 0,
+  crawford: false,
+  jacoby: false,
+  beavers: false,
+}
+
+describe('AI independence — analyzers do not consume dice entropy', () => {
+  const __dirname = path.dirname(fileURLToPath(import.meta.url))
+  const pluginsDir = path.join(__dirname, '../../plugins')
+  let analyzers: Record<string, any> = {}
+  let rollDieSpy: ReturnType<typeof jest.spyOn>
+
+  beforeAll(async () => {
+    analyzers = await loadAnalyzersFromPluginsDir(pluginsDir)
+  })
+
+  beforeEach(() => {
+    rollDieSpy = jest.spyOn(Dice, 'rollDie')
+  })
+
+  afterEach(() => {
+    rollDieSpy.mockRestore()
+  })
+
+  const shippedAnalyzers = [
+    'randomMoveAnalyzer',
+    'furthestFromOffMoveAnalyzer',
+    'nodotsAIMoveAnalyzer',
+    'examplePluginAnalyzer',
+    'gnubgMoveAnalyzer',
+  ]
+
+  it.each(shippedAnalyzers)(
+    '%s.selectMove does not call Dice.rollDie',
+    async (analyzerName) => {
+      const analyzer = analyzers[analyzerName]
+      expect(analyzer).toBeDefined()
+
+      await analyzer.selectMove(moves as any, {
+        hintRequest,
+        positionId: '4HPwATDgc/ABMA',
+      })
+
+      expect(rollDieSpy).not.toHaveBeenCalled()
+    }
+  )
+
+  it('baseline sanity — the spy fires when Dice.rollDie is called directly', () => {
+    Dice.rollDie()
+    expect(rollDieSpy).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

Adds a test suite that asserts every shipped move analyzer leaves \`Dice.rollDie\` (from \`@nodots/backgammon-core\`) untouched during \`selectMove\`. Phase 1.2 of [nodots/backgammon#327](https://github.com/nodots/backgammon/issues/327), sub-issue [#331](https://github.com/nodots/backgammon/issues/331).

## Invariant

Move selection reads the legal-move set and the board. It does not roll dice. An analyzer that calls \`Dice.rollDie\` during selection either:

- (a) peeks at an upcoming opponent roll, or
- (b) advances the RNG in a way that biases subsequent game rolls.

Both would regress the fairness story in [Paper 12 §9.1](https://github.com/nodots/backgammon/pull/329). The test is defensive — no current analyzer calls \`rollDie\`. The purpose is to catch the regression at the moment a new analyzer introduces one.

## Shape

- Installs a \`jest.spyOn(Dice, 'rollDie')\` in \`beforeEach\`, restores in \`afterEach\`.
- \`it.each\` walks every shipped plugin: \`randomMoveAnalyzer\`, \`furthestFromOffMoveAnalyzer\`, \`nodotsAIMoveAnalyzer\`, \`examplePluginAnalyzer\`, \`gnubgMoveAnalyzer\`.
- Each test calls \`selectMove\` with a synthetic move list and a minimal \`hintRequest\` context, then asserts the spy registered zero calls.
- \`@nodots/gnubg-hints\` is mocked via \`jest.unstable_mockModule\` so the GNU analyzer path exercises without the native addon (same pattern as the existing \`pluginAnalyzers.test.ts\`).
- A baseline-sanity test calls \`Dice.rollDie()\` directly and asserts the spy registers 1 call — guards against silent passes if the spy setup breaks.

## Test plan

- [x] \`NODE_OPTIONS=--experimental-vm-modules npx jest src/__tests__/ai-independence.test.ts\` — 6/6 pass (5 analyzers + baseline).
- [x] Runs cleanly alongside the existing \`pluginAnalyzers.test.ts\` — 10/10 pass together, 2/2 suites.
- [x] Pre-existing failures in other test files (stack-overflow during CJS resolution in \`gbg-bot-failure.test.ts\` etc.) are unchanged — verified against clean \`development\` before this commit.

## Infrastructure note

This test, like the existing \`pluginAnalyzers.test.ts\` and several other ai tests, requires \`NODE_OPTIONS=--experimental-vm-modules\` because it uses \`jest.unstable_mockModule\` and top-level \`await import()\` (the ai package's \`jest.config.js\` sets \`extensionsToTreatAsEsm: ['.ts']\` and \`useESM: true\`). The current \`npm test\` script in this package does **not** set the flag, so \`npm test\` fails for these tests — a pre-existing issue across the package. Recent CI runs on \`development\` are all failing for the same reason. This PR does not attempt to fix the package-wide test-runner config; that's worth its own PR.

To run this test locally: \`NODE_OPTIONS=--experimental-vm-modules npx jest src/__tests__/ai-independence.test.ts\`.

## Related

- Tracker: [nodots/backgammon#327](https://github.com/nodots/backgammon/issues/327)
- Sub-issue: [nodots/backgammon#331](https://github.com/nodots/backgammon/issues/331)
- Phase 1.1 (merged): [nodots/backgammon-core#126](https://github.com/nodots/backgammon-core/pull/126)
- White paper: [nodots/backgammon#329](https://github.com/nodots/backgammon/pull/329)