### PR TITLE
fix(robot): no silent fallbacks for bear-off ties or bar reentry (#41)

### DIFF
--- a/src/__tests__/issue-41-bear-off-win.test.ts
+++ b/src/__tests__/issue-41-bear-off-win.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Regression for issue nodots/backgammon-ai#41
+ *
+ * In production game bf09273a-0f04-459a-bc9a-79dd94dcc80c the GNU Intermediate
+ * robot threw away an immediate, trivial win on the final turn. Black had two
+ * checkers in its home board (cw23/ccw2 and cw24/ccw1), 13 already off, and
+ * rolled (1,4). The unique winning play is to bear off both. The robot
+ * instead played die-1 as 2->1 (point-to-point) then die-4 as 1->off, leaving
+ * one checker on the board.
+ *
+ * Root cause (verified locally with the real native addon): GNU returns two
+ * hints with essentially-tied equity (~1.0 + float noise):
+ *
+ *   #0  equity=1.0000005   2->1 (point-to-point)  1->0 (bear-off)   <- slow
+ *   #1  equity=0.9999995   1->0 (bear-off)        2->0 (bear-off)   <- wins
+ *
+ * The robot was blindly taking hints[0]. The fix in robotExecution.ts adds an
+ * equity-tied tiebreaker that prefers the line with more bear-offs, which
+ * matches the racing principle "off > pips" without overriding GNU's actual
+ * judgment in non-tied positions.
+ *
+ * This test mocks the engine with the exact two-hint payload observed for
+ * the production position and asserts that the AI executes the immediate-win
+ * sequence.
+ */
+
+import { beforeEach, describe, expect, it, jest } from '@jest/globals'
+
+let plannedHints: any[] = []
+let executeCalls: string[] = []
+let currentReadyMoves: any[] = []
+
+const initializeMock = jest.fn().mockResolvedValue(undefined)
+const configureMock = jest.fn().mockResolvedValue(undefined)
+const getHintsMock = jest.fn(() => Promise.resolve(plannedHints))
+
+const executeAndRecalculateMock = jest.fn(
+  (game: any, originId: string, _options?: any) => {
+    executeCalls.push(originId)
+    // Drop the matching ready move; if any ready remain, the loop continues.
+    const remaining = ((game.activePlay?.moves || []) as any[]).filter(
+      (m: any) =>
+        !(m.possibleMoves || []).some((pm: any) => pm?.origin?.id === originId)
+    )
+    currentReadyMoves = remaining
+    return {
+      ...game,
+      activePlay: { ...game.activePlay, moves: remaining },
+      stateKind: remaining.length > 0 ? 'moving' : 'moved',
+    }
+  }
+)
+const checkAndCompleteTurnMock = jest.fn((game: any) => ({
+  ...game,
+  stateKind: 'moved',
+}))
+const handleRobotMovedStateMock = jest.fn((game: any) => ({
+  ...game,
+  stateKind: 'rolling',
+}))
+const exportToGnuPositionIdMock = jest.fn(() => 'rwcAABQAAAAAAA')
+
+jest.unstable_mockModule('@nodots/gnubg-hints', () => ({
+  GnuBgHints: {
+    initialize: initializeMock,
+    configure: configureMock,
+    getHintsFromPositionId: getHintsMock,
+  },
+}))
+
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+}
+
+const getPossibleMovesMock = jest.fn(
+  (_board: any, _player: any, dieValue: any) => {
+    const match = currentReadyMoves.find((m) => m?.dieValue === dieValue)
+    return match?.possibleMoves || []
+  }
+)
+
+jest.unstable_mockModule('@nodots/backgammon-core', () => ({
+  Board: { getPossibleMoves: getPossibleMovesMock },
+  Game: {
+    executeAndRecalculate: executeAndRecalculateMock,
+    checkAndCompleteTurn: checkAndCompleteTurnMock,
+    handleRobotMovedState: handleRobotMovedStateMock,
+  },
+  exportToGnuPositionId: exportToGnuPositionIdMock,
+  logger: noopLogger,
+}))
+
+const { executeRobotTurnWithGNU } = await import('../robotExecution.js')
+
+const buildBearOffGame = () => {
+  // Black is counterclockwise. ccw2 has one checker, ccw1 has one checker.
+  // GNU's `from`/`to` for black are in counterclockwise position numbers.
+  const point2 = {
+    id: 'point-ccw2',
+    kind: 'point',
+    position: { clockwise: 23, counterclockwise: 2 },
+    checkers: [{ color: 'black' }],
+  }
+  const point1 = {
+    id: 'point-ccw1',
+    kind: 'point',
+    position: { clockwise: 24, counterclockwise: 1 },
+    checkers: [{ color: 'black' }],
+  }
+  const offCcw = { id: 'off-ccw', kind: 'off', checkers: [] }
+  const offCw = { id: 'off-cw', kind: 'off', checkers: [] }
+
+  const die1Move = {
+    id: 'm-die1',
+    stateKind: 'ready',
+    moveKind: 'point-to-point',
+    dieValue: 1,
+    possibleMoves: [
+      {
+        // 2 -> 1 (the slow option)
+        origin: point2,
+        destination: point1,
+        dieValue: 1,
+      },
+      {
+        // 1 -> off (bear off the 1-point)
+        origin: point1,
+        destination: offCcw,
+        dieValue: 1,
+      },
+    ],
+  }
+  const die4Move = {
+    id: 'm-die4',
+    stateKind: 'ready',
+    moveKind: 'bear-off',
+    dieValue: 4,
+    possibleMoves: [
+      {
+        // 2 -> off (overshoot bear off the 2-point)
+        origin: point2,
+        destination: offCcw,
+        dieValue: 4,
+      },
+    ],
+  }
+
+  const activePlayer = {
+    id: 'player-black',
+    color: 'black',
+    direction: 'counterclockwise',
+    stateKind: 'moving',
+    isRobot: true,
+    dice: { stateKind: 'rolled', currentRoll: [1, 4] },
+  }
+
+  currentReadyMoves = [die1Move, die4Move]
+
+  return {
+    id: 'game-issue-41',
+    stateKind: 'moving',
+    board: {
+      id: 'board-1',
+      points: Array.from({ length: 24 }, (_, i) => {
+        if (i + 1 === 23) return point2
+        if (i + 1 === 24) return point1
+        return {
+          id: `point-${i + 1}`,
+          kind: 'point',
+          position: { clockwise: i + 1, counterclockwise: 24 - i },
+          checkers: [],
+        }
+      }),
+      bar: {
+        clockwise: { id: 'bar-cw', kind: 'bar', checkers: [] },
+        counterclockwise: { id: 'bar-ccw', kind: 'bar', checkers: [] },
+      },
+      off: { clockwise: offCw, counterclockwise: offCcw },
+    },
+    activeColor: 'black',
+    activePlayer,
+    activePlay: {
+      id: 'play-1',
+      stateKind: 'moving',
+      player: activePlayer,
+      moves: [die1Move, die4Move],
+    },
+    players: [activePlayer],
+  }
+}
+
+beforeEach(() => {
+  plannedHints = []
+  executeCalls = []
+  currentReadyMoves = []
+  executeAndRecalculateMock.mockClear()
+  handleRobotMovedStateMock.mockClear()
+})
+
+describe('issue #41: GNU equity-tie tiebreaker prefers immediate-win line', () => {
+  it('picks the bear-off-both line over an equity-tied 2->1 then 1->off line', async () => {
+    // The exact ordering observed from the real native addon for position
+    // rwcAABQAAAAAAA with roll [1,4]: hints[0] is the slow line, hints[1]
+    // wins immediately. Equities are within float-precision noise of 1.0.
+    plannedHints = [
+      {
+        equity: 1.0000004768371582,
+        moves: [
+          { from: 2, to: 1, moveKind: 'point-to-point', player: 'black' },
+          { from: 1, to: 0, moveKind: 'bear-off', player: 'black' },
+        ],
+      },
+      {
+        equity: 0.9999995231628418,
+        moves: [
+          { from: 1, to: 0, moveKind: 'bear-off', player: 'black' },
+          { from: 2, to: 0, moveKind: 'bear-off', player: 'black' },
+        ],
+      },
+    ]
+
+    const game = buildBearOffGame()
+
+    await executeRobotTurnWithGNU(game as any)
+
+    // Both executed steps should be bear-offs, not the point-to-point 2->1.
+    expect(executeCalls).toHaveLength(2)
+    expect(executeCalls).toContain('point-ccw2') // 2 -> off
+    expect(executeCalls).toContain('point-ccw1') // 1 -> off
+  })
+
+  it('still follows hints[0] when no other hint is within equity tolerance', async () => {
+    // If GNU genuinely prefers a non-bear-off line (equities far apart), the
+    // tiebreaker must NOT override its judgment.
+    plannedHints = [
+      {
+        equity: 0.5,
+        moves: [
+          { from: 2, to: 1, moveKind: 'point-to-point', player: 'black' },
+          { from: 1, to: 0, moveKind: 'bear-off', player: 'black' },
+        ],
+      },
+      {
+        equity: 0.2,
+        moves: [
+          { from: 1, to: 0, moveKind: 'bear-off', player: 'black' },
+          { from: 2, to: 0, moveKind: 'bear-off', player: 'black' },
+        ],
+      },
+    ]
+
+    const game = buildBearOffGame()
+
+    await executeRobotTurnWithGNU(game as any)
+
+    // First step is the point-to-point 2->1 -> origin id is point-ccw2 with
+    // destination point-ccw1.
+    expect(executeCalls[0]).toBe('point-ccw2')
+  })
+})

--- a/src/__tests__/robot-bar-first-enforcement.test.ts
+++ b/src/__tests__/robot-bar-first-enforcement.test.ts
@@ -10,6 +10,7 @@ let plannedMoves: any[] = []
 let executeCalls: string[] = []
 let executeOptions: Array<any | undefined> = []
 let executeBehavior: (game: any, originId: string) => any
+let currentReadyMoves: any[] = []
 
 const initializeMock = jest.fn().mockResolvedValue(undefined)
 const configureMock = jest.fn().mockResolvedValue(undefined)
@@ -18,14 +19,17 @@ const getHintsMock = jest.fn(() => Promise.resolve([{ moves: plannedMoves }]))
 const executeAndRecalculateMock = jest.fn((game: any, originId: string, options?: any) => {
   executeCalls.push(originId)
   executeOptions.push(options)
-  if (executeBehavior) {
-    return executeBehavior(game, originId)
-  }
-  return {
-    ...game,
-    activePlay: { ...game.activePlay, moves: [] },
-    stateKind: 'moving',
-  }
+  const next = executeBehavior
+    ? executeBehavior(game, originId)
+    : {
+        ...game,
+        activePlay: { ...game.activePlay, moves: [] },
+        stateKind: 'moving',
+      }
+  // Keep the getPossibleMoves mock in sync with the new working game so the
+  // next iteration's recomputation sees fresh fixture data.
+  currentReadyMoves = next?.activePlay?.moves || []
+  return next
 })
 const checkAndCompleteTurnMock = jest.fn((game: any) => ({
   ...game,
@@ -45,14 +49,33 @@ jest.unstable_mockModule('@nodots/gnubg-hints', () => ({
   },
 }))
 
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+}
+
+// `executeRobotTurnWithGNU` recomputes possibleMoves each iteration via
+// Board.getPossibleMoves to defeat staleness. The mocked engine here doesn't
+// model the board, so make the recomputation a passthrough: return whatever
+// the test fixture put on the matching ready move (looked up in a shared
+// `currentReadyMoves` reference that each step's executeBehavior can update).
+const getPossibleMovesMock = jest.fn((_board: any, _player: any, dieValue: any) => {
+  const match = currentReadyMoves.find((m) => m?.dieValue === dieValue)
+  return match?.possibleMoves || []
+})
+
 jest.unstable_mockModule('@nodots/backgammon-core', () => ({
-  Board: {},
+  Board: { getPossibleMoves: getPossibleMovesMock },
   Game: {
     executeAndRecalculate: executeAndRecalculateMock,
     checkAndCompleteTurn: checkAndCompleteTurnMock,
     confirmTurn: confirmTurnMock,
+    handleRobotMovedState: jest.fn((g: any) => g),
   },
   exportToGnuPositionId: exportToGnuPositionIdMock,
+  logger: noopLogger,
 }))
 
 const { executeRobotTurnWithGNU } = await import('../robotExecution.js')
@@ -100,6 +123,10 @@ const createGame = (readyMoves: any[]) => {
     isRobot: true,
     dice: { stateKind: 'rolled', currentRoll: [1, 2] },
   }
+  // The Board.getPossibleMoves mock looks up possibleMoves by dieValue from
+  // currentReadyMoves -- keep it in sync with the initial ready moves so the
+  // first iteration's recomputation returns what the fixture set up.
+  currentReadyMoves = readyMoves
   return {
     id: 'game-1',
     stateKind: 'moving',
@@ -176,7 +203,10 @@ beforeEach(() => {
 })
 
 describe('executeRobotTurnWithGNU bar-first enforcement', () => {
-  it('prefers bar reentry even when GNU plans a point-to-point move', async () => {
+  it('throws when GNU plans a point-to-point move while bar reentry is required', async () => {
+    // Game-rule view: bar checkers MUST move first. CLAUDE.md absolute-rule
+    // view: if GNU's plan disagrees, the encoding/translation has drifted --
+    // refuse to silently substitute and surface the diagnostic instead.
     plannedMoves = [
       {
         from: 24,
@@ -195,11 +225,16 @@ describe('executeRobotTurnWithGNU bar-first enforcement', () => {
     ]
     const game = createGame(readyMoves)
 
-    await expect(executeRobotTurnWithGNU(game as any)).resolves.toBeDefined()
-    expect(executeCalls[0]).toBe('bar-cw')
+    await expect(executeRobotTurnWithGNU(game as any)).rejects.toThrow(
+      /required bar reentry/
+    )
+    expect(executeCalls).toEqual([])
   })
 
-  it('falls back to a bar move when GNU plan has no legal match', async () => {
+  it('throws (no silent fallback) when GNU plan has no legal bar match', async () => {
+    // Per CLAUDE.md absolute rule: when GNU plans a non-bar move while bar
+    // checkers are still on the board, refuse to silently substitute a bar
+    // reentry. The encoding/translation layer is broken and must be fixed.
     plannedMoves = [
       {
         from: 24,
@@ -215,11 +250,13 @@ describe('executeRobotTurnWithGNU bar-first enforcement', () => {
     const readyMoves = [createBarMove(1, 24)]
     const game = createGame(readyMoves)
 
-    await expect(executeRobotTurnWithGNU(game as any)).resolves.toBeDefined()
-    expect(executeCalls[0]).toBe('bar-cw')
+    await expect(executeRobotTurnWithGNU(game as any)).rejects.toThrow(
+      /required bar reentry/
+    )
+    expect(executeCalls).toEqual([])
   })
 
-  it('does not execute a stale non-bar step while bar checkers remain', async () => {
+  it('throws on a stale non-bar step while bar checkers remain', async () => {
     plannedMoves = [
       {
         from: 25,
@@ -261,8 +298,12 @@ describe('executeRobotTurnWithGNU bar-first enforcement', () => {
     const readyMoves = [createBarMove(1, 24)]
     const game = createGame(readyMoves)
 
-    await expect(executeRobotTurnWithGNU(game as any)).resolves.toBeDefined()
-    expect(executeCalls).toEqual(['bar-cw', 'bar-cw'])
+    // First step (reenter) succeeds and matches the bar reentry. Second step's
+    // plan is a non-bar move while a bar checker still remains -- must throw.
+    await expect(executeRobotTurnWithGNU(game as any)).rejects.toThrow(
+      /required bar reentry/
+    )
+    expect(executeCalls).toEqual(['bar-cw'])
   })
 
   it('passes exact destination and die when matching a bar reentry plan', async () => {

--- a/src/robotExecution.ts
+++ b/src/robotExecution.ts
@@ -219,11 +219,11 @@ export const executeRobotTurnWithGNU = async (
       'clockwise'
     const activePlayerColor =
       ((currentGame.activePlayer as any)?.color as BackgammonColor) ?? 'white'
-    // GNU rNoise is the sole noise mechanism -- always request 1 hint
+    // Request multiple hints so the tiebreaker below has alternatives.
     const hints = await GnuBgHints.getHintsFromPositionId(
       planPositionId,
       currentRoll,
-      1,
+      5,
       activePlayerDirection,
       activePlayerColor
     )
@@ -231,7 +231,32 @@ export const executeRobotTurnWithGNU = async (
       return []
     }
 
-    return hints[0]?.moves || []
+    // Issue nodots/backgammon-ai#41: in races and bear-off endgames GNU's
+    // evaluator can rank multiple winning lines essentially equally (deltas
+    // within float-precision noise). Picking hints[0] blindly threw away an
+    // immediate win in production game bf09273a-... when hints[1] bore off
+    // both checkers. Among lines tied within EQUITY_TIE_EPSILON, prefer the
+    // one that bears off more checkers this turn -- the racing principle
+    // "off > pips" is a strict improvement when equity is genuinely tied.
+    const EQUITY_TIE_EPSILON = 1e-3
+    const topEquity = hints[0].equity ?? 0
+    const tied = hints.filter(
+      (h) => Math.abs((h.equity ?? 0) - topEquity) <= EQUITY_TIE_EPSILON
+    )
+    const bearOffCount = (h: { moves?: MoveStep[] }) =>
+      (h.moves || []).filter((m) => m.moveKind === 'bear-off').length
+    const best = tied.reduce((a, b) =>
+      bearOffCount(b) > bearOffCount(a) ? b : a
+    )
+    if (best !== hints[0]) {
+      logger.info('[AI] Tiebreak selected hint with more bear-offs', {
+        topEquity,
+        chosenEquity: best.equity,
+        topBearOffs: bearOffCount(hints[0]),
+        chosenBearOffs: bearOffCount(best),
+      })
+    }
+    return best.moves || []
   }
 
   // Get plan ONCE before the loop (true one-shot planning to avoid die-tracking bug #250)
@@ -397,16 +422,36 @@ export const executeRobotTurnWithGNU = async (
         }
       }
       if (!barMatchedId) {
-        logger.info('[BAR-DEBUG] No match found, using fallback')
-        const firstBarMove = barMoves.find((m) =>
-          Array.isArray(m.possibleMoves)
+        // ABSOLUTE RULE (CLAUDE.md): no silent fallbacks in AI code. If GNU's
+        // plan does not include a bar reentry while bar checkers are still on
+        // the board, the position-encoding / move-translation has drifted --
+        // throw with diagnostics rather than guess a substitute.
+        const dirForDiag =
+          (workingGame.activePlayer as any)?.direction || 'clockwise'
+        const diag = {
+          positionId,
+          plannedFrom,
+          plannedTo,
+          plannedKind,
+          direction: dirForDiag,
+          barCheckersByDirection: barByDir,
+          barCheckersByColor: barBothDirs,
+          legalBarReentries: barMoves.flatMap((m) =>
+            (m.possibleMoves || [])
+              .filter((pm: any) => pm?.origin?.kind === 'bar')
+              .map((pm: any) => ({
+                dieValue: (pm as any)?.dieValue ?? (m as any)?.dieValue,
+                destPos: (pm as any)?.destination?.position?.[dirForDiag],
+              }))
+          ),
+        }
+        logger.error(
+          '[AI] GNU plan does not match required bar reentry',
+          diag
         )
-        const fallbackMove = firstBarMove?.possibleMoves?.[0]
-        barMatchedId = fallbackMove?.origin?.id ?? null
-        desiredDestinationId = fallbackMove?.destination?.id ?? null
-        expectedDieValue =
-          (fallbackMove as any)?.dieValue ?? (firstBarMove as any)?.dieValue
-        logger.info('[BAR-DEBUG] Fallback: barMatchedId=', barMatchedId, 'destId=', desiredDestinationId, 'die=', expectedDieValue)
+        throw new Error(
+          `[AI] GNU plan does not include required bar reentry; refusing to silently substitute. ${JSON.stringify(diag)}`
+        )
       }
       if (barMatchedId) {
         originIdToUse = barMatchedId


### PR DESCRIPTION
## Summary

Fixes nodots/backgammon-ai#41. Two related no-silent-fallback fixes in `executeRobotTurnWithGNU`:

1. **Equity-tied bear-off tiebreaker.** GNU's Intermediate evaluator can rank multiple winning lines essentially equally — in production game `bf09273a-0f04-459a-bc9a-79dd94dcc80c` it picked `hints[0]` (2→1 then 1→off, leaving one checker on the board) over an equity-tied `hints[1]` that bore off both checkers immediately. We now request 5 hints and, among lines within `EQUITY_TIE_EPSILON` (1e-3) of the top equity, pick the one with more bear-offs this turn. Strict improvement when equity is genuinely tied (the racing principle "off > pips"); does nothing in non-tied positions.

2. **Bar-reentry fallback removed.** Per `CLAUDE.md`'s absolute rule on no silent fallbacks in AI code, when GNU's plan does not include the required bar reentry while bar checkers remain on the board, the code now throws with full diagnostics (positionId, planned move, legal bar reentries) instead of substituting a guessed reentry. Surfaces encoding/translation drift instead of masking it as random play.

Bar-first-enforcement tests updated to assert the throws. New regression test `issue-41-bear-off-win.test.ts` pins the `bf09273a` position with the exact two-hint payload observed from the native addon.

## Test plan

- [x] `npm test -- --testPathPattern=issue-41-bear-off-win` (2 passed)
- [x] `npm test -- --testPathPattern=robot-bar-first-enforcement` (4 passed; previously failing on main)
- [ ] Verify in a robot-vs-robot session that races/bear-off endgames no longer leave a checker behind
- [ ] Watch for any `[AI] Tiebreak selected hint with more bear-offs` info logs in production
- [ ] Watch for any `[AI] GNU plan does not match required bar reentry` errors — these now indicate a real encoding bug rather than being silently papered over