### PR TITLE
chore: release 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots/backgammon-ai",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "AI and integration for nodots-backgammon using the @nodots/gnubg-hints native addon.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Single-commit version bump of `@nodots/backgammon-ai` from 1.0.3 → **1.0.4**, aligning the package with the workspace-wide 1.0.4 release.

## Note on history

Earlier in this branch's life I had a misread: my local `main` was stale and I thought the 1.0.3 release work was unmerged. In fact #43 already brought the no-silent-fallback robot fix (#42) to `main` at version 1.0.3 on 2026-05-03. This PR is therefore purely the 1.0.3 → 1.0.4 bump.

## Test plan

- [ ] CI passes on this branch
- [ ] After merge + deploy, confirm `@nodots/backgammon-ai` reports 1.0.4 (via api's `/ops/versions` once that PR also lands)