### PR TITLE
chore: release @nodots/backgammon-ai 1.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nodots/backgammon-ai",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "AI and integration for nodots-backgammon using the @nodots/gnubg-hints native addon.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Promotes development to main:

- #46 — extract `matchStepToReadyMove` (canonical hint matcher with die-consistency validation), remove the `/tmp` debug file writes that ran on every robot turn in the production worker

Verified in #46: 14 matcher spec cases against the built export, prod-game-2d98cf14 JSON e2e completes with die 5, locally-green suites stay green.