### PR TITLE
[READY]: C0.2 (minimal) — ai imports engine contract from protocol package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,9 @@ gnubg/po/stamp-po
 gnubg/doc/Makefile 
 
 .claude/
+
+# auto-shop cell scaffolding (not part of package source)
+.auto-shop/
+SCOPE.json
+HANDOFF.md
+BLOCKER.md

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@nodots/backgammon-api-utils": "^1.0.0",
+    "@nodots/backgammon-engine-protocol": "github:nodots/backgammon-engine-protocol#development",
     "@nodots/backgammon-core": "^1.0.0",
     "@nodots/backgammon-types": "^1.0.0",
     "@nodots/gnubg-hints": "^1.0.0",

--- a/src/engine/contract.ts
+++ b/src/engine/contract.ts
@@ -1,0 +1,19 @@
+// Single import site for the engine contract, re-exported from the
+// permissive protocol package. Later cells (C1.1) build the EngineProvider
+// abstraction on top of these types.
+export type {
+  AnalysisProvider,
+  Evaluation,
+  MoveHint,
+  MoveStep,
+  DoubleHint,
+  TakeHint,
+  ResignDecision,
+  HealthStatus,
+  HintRequest,
+  Explanation,
+  Color,
+  Direction,
+  Container,
+} from '@nodots/backgammon-engine-protocol'
+export { PROTOCOL_VERSION } from '@nodots/backgammon-engine-protocol'


### PR DESCRIPTION
## C0.2 (minimal) — ai imports engine contract from protocol package

Minimal critical-path slice of `nodots/backgammon#362` (cross-repo reference; will not auto-close). The broader workspace-wide type migration is **deferred / incremental** — this PR only makes the engine contract *available* to the `ai` package from the permissive protocol package. No sweep, no removal of existing `@nodots/gnubg-hints` type usage.

### What changed
- **`package.json`**: added git dependency `@nodots/backgammon-engine-protocol": "github:nodots/backgammon-engine-protocol#development"`. Resolves and builds its `dist/` via its `prepare` script (installed version 0.1.0).
- **`src/engine/contract.ts`** (new): thin module re-exporting the engine contract — `AnalysisProvider`, `Evaluation`, `MoveHint`, `MoveStep`, `DoubleHint`, `TakeHint`, `ResignDecision`, `HealthStatus`, `HintRequest`, `Explanation`, `Color`, `Direction`, `Container`, and the `PROTOCOL_VERSION` value. Single import site for later cells (C1.1 builds the EngineProvider abstraction on top of it).
- **`.gitignore`**: ignore cell scaffolding (`.auto-shop/`, `SCOPE.json`, `HANDOFF.md`, `BLOCKER.md`).

No other files touched. Existing behavior untouched.

### No regression
Build, lint, and the test-suite pass/fail set are identical to the pre-change baseline. The 8 pre-existing failing suites fail before and after this change (native-addon teardown crashes, unrelated to this PR); the new `contract.ts` is not imported by any test.

**Build** (`npm run build`) — exit 0; `dist/engine/contract.js` + `.d.ts` emitted.

**Lint** (`npm run lint`) — exit 0, 0 errors, 5 pre-existing warnings.

**Test** (`npm test`) — suite pass/fail identical to baseline:
```
Test Suites: 8 failed, 3 skipped, 7 passed, 15 of 18 total
Tests:       1 failed, 6 skipped, 40 passed, 47 total
```
A `diff` of the sorted FAIL/PASS suite list vs. the pre-change baseline is empty. The 8 FAIL suites and 7 PASS suites match baseline exactly; the aggregate per-test count fluctuates only within the already-crashing suites (stable across re-runs at 47 total post-change).

### Scope
Stayed in lane: `src/**`, `package.json` (+ task-authorized `.gitignore`). `package-lock.json` is not committed (the repo does not track one). `tsconfig.json` and `.github/**` untouched.
