### PR TITLE
[READY]: C1.1 — engine boundary + InProcessGnuProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,9 @@ gnubg/po/stamp-po
 gnubg/doc/Makefile 
 
 .claude/
+
+# auto-shop cell scaffolding (not part of package source)
+.auto-shop/
+SCOPE.json
+HANDOFF.md
+BLOCKER.md

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@nodots/backgammon-api-utils": "^1.0.0",
+    "@nodots/backgammon-engine-protocol": "github:nodots/backgammon-engine-protocol#development",
     "@nodots/backgammon-core": "^1.0.0",
     "@nodots/backgammon-types": "^1.0.0",
     "@nodots/gnubg-hints": "^1.0.0",

--- a/src/engine/contract.ts
+++ b/src/engine/contract.ts
@@ -1,0 +1,19 @@
+// Single import site for the engine contract, re-exported from the
+// permissive protocol package. Later cells (C1.1) build the EngineProvider
+// abstraction on top of these types.
+export type {
+  AnalysisProvider,
+  Evaluation,
+  MoveHint,
+  MoveStep,
+  DoubleHint,
+  TakeHint,
+  ResignDecision,
+  HealthStatus,
+  HintRequest,
+  Explanation,
+  Color,
+  Direction,
+  Container,
+} from '@nodots/backgammon-engine-protocol'
+export { PROTOCOL_VERSION } from '@nodots/backgammon-engine-protocol'

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,5 +117,15 @@ export { GNUAIProvider } from './GNUAIProvider.js';
 export { NodotsAIProvider } from './NodotsAIProvider.js';
 export { executeRobotTurnWithGNU } from './robotExecution.js';
 
+// Engine boundary: AnalysisProvider contract + in-process GNU implementation.
+// The GNU robot move path routes hint retrieval through inProcessGnuProvider.
+export {
+  InProcessGnuProvider,
+  inProcessGnuProvider,
+} from './providers/InProcessGnuProvider.js';
+// Type-only re-export: the engine-protocol package is import-only (no CJS
+// resolution), so keep the package entry free of a runtime edge into it.
+export type * from './engine/contract.js';
+
 // Export luck analysis
 export * from './luckCalculator.js';

--- a/src/providers/InProcessGnuProvider.ts
+++ b/src/providers/InProcessGnuProvider.ts
@@ -1,0 +1,110 @@
+/**
+ * InProcessGnuProvider
+ *
+ * Implements the language-neutral AnalysisProvider contract (from
+ * src/engine/contract.ts, re-exported out of @nodots/backgammon-engine-protocol)
+ * by delegating to the in-process @nodots/gnubg-hints native addon.
+ *
+ * The contract's request/response shapes are re-authored data definitions that
+ * intentionally match the shapes @nodots/gnubg-hints already produces
+ * (Evaluation / MoveHint / MoveStep / DoubleHint / TakeHint), so the move-hint
+ * path is a direct delegation with no reshaping.
+ *
+ * Boundary note: the contract HintRequest is positionId-based. The addon exposes
+ * getHintsFromPositionId (used by the robot move path), but its cube decisions
+ * (getDoubleHint/getTakeHint) require a decoded board that a positionId-only
+ * request does not carry. Those methods, plus explain, therefore throw rather
+ * than fabricate a result -- consistent with the no-silent-fallback rule. None
+ * of them are on the robot move-execution path this cell routes.
+ */
+
+import { GnuBgHints } from '@nodots/gnubg-hints'
+import type {
+  AnalysisProvider,
+  DoubleHint,
+  Evaluation,
+  Explanation,
+  HealthStatus,
+  HintRequest,
+  MoveHint,
+  ResignDecision,
+  TakeHint,
+} from '../engine/contract.js'
+
+const NOT_SUPPORTED = (method: string): Error =>
+  new Error(
+    `[AI] InProcessGnuProvider.${method} is not supported: the positionId-based ` +
+      `contract request does not carry the board the in-process GNU addon requires ` +
+      `for this decision. Refusing to fabricate a result.`
+  )
+
+export class InProcessGnuProvider implements AnalysisProvider {
+  /**
+   * Return ranked move hints for the position. Delegates directly to the addon
+   * positionId path -- the same call the robot move planner used before this
+   * abstraction, with identical arguments.
+   */
+  async getMoveHints(req: HintRequest, maxHints?: number): Promise<MoveHint[]> {
+    // Contract MoveHint and gnubg MoveHint are the same shape; the addon result
+    // is returned unchanged.
+    return GnuBgHints.getHintsFromPositionId(
+      req.positionId,
+      req.dice,
+      maxHints,
+      req.activePlayerDirection,
+      req.activePlayerColor
+    )
+  }
+
+  /**
+   * Position evaluation, derived from the top-ranked move hint's evaluation.
+   * Throws when the position yields no legal move (no evaluation to report).
+   */
+  async evaluate(req: HintRequest): Promise<Evaluation> {
+    const hints = await this.getMoveHints(req, 1)
+    if (!hints || hints.length === 0) {
+      throw new Error(
+        `[AI] InProcessGnuProvider.evaluate: no hints returned for position ${req.positionId}`
+      )
+    }
+    return hints[0].evaluation
+  }
+
+  async getDoubleHint(_req: HintRequest): Promise<DoubleHint> {
+    throw NOT_SUPPORTED('getDoubleHint')
+  }
+
+  async getTakeHint(_req: HintRequest): Promise<TakeHint> {
+    throw NOT_SUPPORTED('getTakeHint')
+  }
+
+  async getResignDecision(_req: HintRequest): Promise<ResignDecision> {
+    throw NOT_SUPPORTED('getResignDecision')
+  }
+
+  async explain(_req: HintRequest): Promise<Explanation> {
+    throw NOT_SUPPORTED('explain')
+  }
+
+  async health(): Promise<HealthStatus> {
+    await GnuBgHints.initialize()
+    return {
+      status: 'ok',
+      engineName: 'gnubg',
+      engineVersion: 'in-process',
+      // Literal rather than an imported PROTOCOL_VERSION value: the protocol
+      // package ships an import-only exports map, so a runtime value import of
+      // the contract module is unresolvable under this repo's CJS Jest resolver.
+      // The type binds this to HealthStatus.protocolVersion, so a protocol
+      // version bump fails the build here.
+      protocolVersion: '1',
+    }
+  }
+}
+
+/**
+ * Shared default instance. The robot move planner and the package public
+ * surface both consume this single instance, mirroring the gnubgHints singleton
+ * pattern already used in this package.
+ */
+export const inProcessGnuProvider = new InProcessGnuProvider()

--- a/src/robotExecution.ts
+++ b/src/robotExecution.ts
@@ -21,6 +21,8 @@ import type { SkillConfig } from '@nodots/backgammon-api-utils'
 import { GnuBgHints, MoveStep } from '@nodots/gnubg-hints'
 import type { HintConfig } from '@nodots/gnubg-hints'
 import { logger as coreLogger } from '@nodots/backgammon-core'
+import type { HintRequest } from './engine/contract.js'
+import { inProcessGnuProvider } from './providers/InProcessGnuProvider.js'
 
 // Lazy imports to break circular dependency (ESM-compatible)
 let Core: any = null
@@ -315,13 +317,23 @@ export const executeRobotTurnWithGNU = async (
     const activePlayerColor =
       ((currentGame.activePlayer as any)?.color as BackgammonColor) ?? 'white'
     // Request multiple hints so the tiebreaker below has alternatives.
-    const hints = await GnuBgHints.getHintsFromPositionId(
-      planPositionId,
-      currentRoll,
-      5,
+    // Routed through the AnalysisProvider boundary (InProcessGnuProvider),
+    // which delegates to GnuBgHints.getHintsFromPositionId with the same
+    // arguments. cube/match fields are inert on the positionId hint path.
+    const hintRequest: HintRequest = {
+      positionId: planPositionId,
+      dice: currentRoll,
+      activePlayerColor,
       activePlayerDirection,
-      activePlayerColor
-    )
+      cubeValue: 1,
+      cubeOwner: null,
+      matchScore: [0, 0],
+      matchLength: 0,
+      crawford: false,
+      jacoby: false,
+      beavers: false,
+    }
+    const hints = await inProcessGnuProvider.getMoveHints(hintRequest, 5)
     if (!hints || hints.length === 0) {
       return []
     }


### PR DESCRIPTION
## C1.1 — engine boundary + InProcessGnuProvider

Cross-repo: implements cell **C1.1** of nodots/backgammon#366 in `nodots/backgammon-ai`.

Abstracts the engine call site in the `ai` package behind the `AnalysisProvider` contract, with GNU wrapped as `InProcessGnuProvider`. **Zero behavioral regression** on the robot move path.

### What changed
- **`src/providers/InProcessGnuProvider.ts` (new)** — implements the `AnalysisProvider` contract (`src/engine/contract.ts`, re-exported from `@nodots/backgammon-engine-protocol`) by delegating to the in-process `@nodots/gnubg-hints` addon. `getMoveHints` forwards `positionId`/`dice`/`direction`/`color` to `GnuBgHints.getHintsFromPositionId` with identical arguments; `evaluate` derives from the top hint. The addon's cube decisions (`getDoubleHint`/`getTakeHint`), `getResignDecision`, and `explain` throw rather than fabricate a result — the positionId-based contract request carries no board for the addon's board-based cube API, and none are on the robot move path (consistent with the no-silent-fallback rule).
- **`src/robotExecution.ts`** — the GNU move planner now obtains hints through an `InProcessGnuProvider` instance instead of calling `GnuBgHints.getHintsFromPositionId` directly. Same inputs/outputs; `GnuBgHints.initialize`/`configure` are unchanged.
- **`src/index.ts`** — exports `InProcessGnuProvider` + `inProcessGnuProvider` and (type-only) the contract; no change to `RobotAIRegistry` routing.

### Dependency note (C0.2)
This branch was cut from `origin/development`, which does **not** yet contain C0.2's `src/engine/contract.ts` + the `@nodots/backgammon-engine-protocol` dependency. C1.1 requires that contract, so **C0.2 (`feat/engine-protocol-import`) is merged in** here (it only touches `.gitignore`, `package.json`, `src/engine/contract.ts`). When C0.2 lands in `development` first, this PR's diff reduces to the three source files above.

The engine-protocol package ships an **import-only `exports` map** (no `require`/`default`), so a runtime *value* import of the contract module is unresolvable under this repo's CJS Jest resolver (`jest.resolver.cjs`). To keep zero test regression without touching out-of-lane build config, the provider and package entry import the contract **type-only** and `health()` uses the type-bound literal `'1'` for `protocolVersion` (a protocol-version bump fails the build here).

### No-regression verification
Full `jest` suite run on the base (`origin/development`) and after the change. **Failing-suite set is byte-identical** (the ~8 pre-existing native-addon suite failures). Build/typecheck clean (`tsc -b --force`, exit 0).

**Baseline (origin/development) — 8 failing suites:**
```
FAIL src/__tests__/bar-reentry-dice-bug.test.ts
FAIL src/__tests__/gbg-bot-failure.test.ts
FAIL src/__tests__/gnu-nodots-roundtrip.test.ts
FAIL src/__tests__/index.test.ts
FAIL src/__tests__/pid-orientation-original.test.ts
FAIL src/__tests__/position-matcher.test.ts
FAIL src/__tests__/robot-hint-arguments.test.ts
FAIL src/__tests__/robot-reentry-no-move.test.ts
```

**After change — 8 failing suites (identical set):**
```
FAIL src/__tests__/bar-reentry-dice-bug.test.ts
FAIL src/__tests__/gbg-bot-failure.test.ts
FAIL src/__tests__/gnu-nodots-roundtrip.test.ts
FAIL src/__tests__/index.test.ts
FAIL src/__tests__/pid-orientation-original.test.ts
FAIL src/__tests__/position-matcher.test.ts
FAIL src/__tests__/robot-hint-arguments.test.ts
FAIL src/__tests__/robot-reentry-no-move.test.ts
```
`diff` of the two FAIL lists is empty. Previously-passing `issue-41-bear-off-win`, `robot-bar-first-enforcement`, and `robot-bearoff-larger-die` remain passing.

Refs nodots/backgammon#366
