### PR TITLE
[READY]: C1.2 — HttpEngineProvider

### DIFF
--- a/src/__tests__/http-engine-provider.test.ts
+++ b/src/__tests__/http-engine-provider.test.ts
@@ -1,0 +1,335 @@
+/**
+ * HttpEngineProvider unit tests.
+ *
+ * The vendor is a real in-process http.Server so the full request path exercises
+ * fetch, headers, HMAC signing, AbortController timeouts and JSON round-tripping
+ * -- no fetch mock. Each test drives the provider against a server whose handler
+ * is swapped per case.
+ */
+
+import { createHmac } from 'node:crypto'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+import type {
+  HintRequest,
+  MoveHint,
+  MoveResponse,
+} from '../engine/contract.js'
+import {
+  HttpEngineProvider,
+  type HttpEngineProviderConfig,
+} from '../providers/HttpEngineProvider.js'
+import { IllegalVendorMoveError } from '../engine/moveValidation.js'
+
+// --- fixtures --------------------------------------------------------------
+
+const API_KEY = 'test-api-key'
+const HMAC_SECRET = 'test-hmac-secret'
+
+const secretResolver = (ref: string): string | undefined =>
+  ({ API_KEY_REF: API_KEY, HMAC_REF: HMAC_SECRET })[ref]
+
+const baseRequest = (): HintRequest => ({
+  positionId: '4HPwATDgc/ABMA',
+  dice: [3, 1],
+  activePlayerColor: 'white',
+  activePlayerDirection: 'clockwise',
+  cubeValue: 1,
+  cubeOwner: null,
+  matchScore: [0, 0],
+  matchLength: 1,
+  crawford: false,
+  jacoby: true,
+  beavers: false,
+})
+
+// A legal play 8/5 6/5 expressed as MoveStep[].
+const legalPlaySteps = (): MoveResponse['moves'] => [
+  {
+    from: 8,
+    to: 5,
+    moveKind: 'point-to-point',
+    isHit: false,
+    player: 'white',
+    fromContainer: 'point',
+    toContainer: 'point',
+  },
+  {
+    from: 6,
+    to: 5,
+    moveKind: 'point-to-point',
+    isHit: false,
+    player: 'white',
+    fromContainer: 'point',
+    toContainer: 'point',
+  },
+]
+
+const legalHints = (): MoveHint[] => [
+  {
+    moves: legalPlaySteps(),
+    evaluation: {
+      win: 0.55,
+      winGammon: 0.1,
+      winBackgammon: 0.01,
+      loseGammon: 0.05,
+      loseBackgammon: 0.0,
+      equity: 0.12,
+    },
+    equity: 0.12,
+    rank: 0,
+    difference: 0,
+  },
+]
+
+interface CapturedRequest {
+  method: string
+  url: string
+  headers: http.IncomingHttpHeaders
+  body: string
+}
+
+/** A per-test mock vendor. handler returns [status, jsonBody] or delays. */
+interface MockVendor {
+  url: string
+  captured: CapturedRequest[]
+  close: () => Promise<void>
+}
+
+type Handler = (
+  req: CapturedRequest,
+  res: http.ServerResponse
+) => void | Promise<void>
+
+async function startVendor(handler: Handler): Promise<MockVendor> {
+  const captured: CapturedRequest[] = []
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (c) => chunks.push(c as Buffer))
+    req.on('end', () => {
+      const captured1: CapturedRequest = {
+        method: req.method ?? '',
+        url: req.url ?? '',
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      }
+      captured.push(captured1)
+      Promise.resolve(handler(captured1, res)).catch(() => {
+        if (!res.headersSent) {
+          res.writeHead(500)
+          res.end('handler error')
+        }
+      })
+    })
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+  return {
+    url: `http://127.0.0.1:${port}`,
+    captured,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      ),
+  }
+}
+
+const jsonReply =
+  (status: number, payload: unknown): Handler =>
+  (_req, res) => {
+    res.writeHead(status, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(payload))
+  }
+
+function makeProvider(
+  vendorUrl: string,
+  overrides: Partial<HttpEngineProviderConfig> = {}
+): HttpEngineProvider {
+  return new HttpEngineProvider({
+    baseUrl: vendorUrl,
+    apiKeyRef: 'API_KEY_REF',
+    engineId: 'test-vendor',
+    secretResolver,
+    ...overrides,
+  })
+}
+
+// --- tests -----------------------------------------------------------------
+
+describe('HttpEngineProvider', () => {
+  it('round-trips a position to a move via POST /v1/move', async () => {
+    const moveResponse: MoveResponse = {
+      moves: legalPlaySteps(),
+      equity: 0.12,
+      candidates: legalHints(),
+    }
+    const vendor = await startVendor(jsonReply(200, moveResponse))
+    try {
+      const provider = makeProvider(vendor.url, {
+        legalMoveResolver: async () => legalHints(),
+      })
+      const hints = await provider.getMoveHints(baseRequest())
+
+      expect(hints).toHaveLength(1)
+      expect(hints[0].moves.map((m) => `${m.from}/${m.to}`)).toEqual([
+        '8/5',
+        '6/5',
+      ])
+      // Request landed on the right endpoint with auth + engine-id headers.
+      const call = vendor.captured[0]
+      expect(call.method).toBe('POST')
+      expect(call.url).toBe('/v1/move')
+      expect(call.headers.authorization).toBe(`Bearer ${API_KEY}`)
+      expect(call.headers['x-nodots-engine-id']).toBe('test-vendor')
+      // No HMAC headers when hmacSecretRef is not configured.
+      expect(call.headers['x-nodots-signature']).toBeUndefined()
+      // Position was carried in the body.
+      expect(JSON.parse(call.body).positionId).toBe('4HPwATDgc/ABMA')
+    } finally {
+      await vendor.close()
+    }
+  })
+
+  it('synthesizes a single hint when the vendor returns no candidates', async () => {
+    const vendor = await startVendor(
+      jsonReply(200, { moves: legalPlaySteps(), equity: 0.2 })
+    )
+    try {
+      const provider = makeProvider(vendor.url)
+      const hints = await provider.getMoveHints(baseRequest())
+      expect(hints).toHaveLength(1)
+      expect(hints[0].equity).toBe(0.2)
+    } finally {
+      await vendor.close()
+    }
+  })
+
+  it('throws IllegalVendorMoveError with diagnostics for an illegal move', async () => {
+    const illegalMove: MoveResponse = {
+      moves: [
+        {
+          from: 13,
+          to: 2,
+          moveKind: 'point-to-point',
+          isHit: false,
+          player: 'white',
+          fromContainer: 'point',
+          toContainer: 'point',
+        },
+      ],
+    }
+    const vendor = await startVendor(jsonReply(200, illegalMove))
+    try {
+      const provider = makeProvider(vendor.url, {
+        legalMoveResolver: async () => legalHints(),
+      })
+      await expect(provider.getMoveHints(baseRequest())).rejects.toThrow(
+        IllegalVendorMoveError
+      )
+      // Re-run to inspect the diagnostic payload.
+      const err = await provider.getMoveHints(baseRequest()).catch((e) => e)
+      expect(err).toBeInstanceOf(IllegalVendorMoveError)
+      expect(err.positionId).toBe('4HPwATDgc/ABMA')
+      expect(err.dice).toEqual([3, 1])
+      expect(err.returnedMove).toHaveLength(1)
+      expect(err.legalMoves).toHaveLength(1)
+      expect(err.message).toContain('13/2')
+      expect(err.message).toContain('Refusing to fall back')
+    } finally {
+      await vendor.close()
+    }
+  })
+
+  it('throws (no fallback) when the request times out', async () => {
+    // Handler never responds; provider must abort at timeoutMs.
+    const vendor = await startVendor(() => {
+      /* hang */
+    })
+    try {
+      const provider = makeProvider(vendor.url, { timeoutMs: 100 })
+      await expect(provider.getMoveHints(baseRequest())).rejects.toThrow(
+        /timed out after 100ms.*Refusing to fall back/s
+      )
+    } finally {
+      await vendor.close()
+    }
+  })
+
+  it('throws (no fallback) on a 5xx response', async () => {
+    const vendor = await startVendor(jsonReply(503, { error: 'overloaded' }))
+    try {
+      const provider = makeProvider(vendor.url)
+      await expect(provider.getMoveHints(baseRequest())).rejects.toThrow(
+        /HTTP 503.*Refusing to fall back/s
+      )
+    } finally {
+      await vendor.close()
+    }
+  })
+
+  it('throws (no fallback) on a network error to an unreachable host', async () => {
+    // Reserved TEST-NET-1 address that refuses/blackholes connections fast
+    // enough under the configured timeout.
+    const provider = makeProvider('http://127.0.0.1:1', { timeoutMs: 500 })
+    await expect(provider.getMoveHints(baseRequest())).rejects.toThrow(
+      /Refusing to fall back/
+    )
+  })
+
+  it('signs requests with HMAC headers when hmacSecretRef is configured', async () => {
+    const vendor = await startVendor(
+      jsonReply(200, { moves: legalPlaySteps() })
+    )
+    try {
+      const provider = makeProvider(vendor.url, { hmacSecretRef: 'HMAC_REF' })
+      await provider.getMoveHints(baseRequest())
+
+      const call = vendor.captured[0]
+      const timestamp = call.headers['x-nodots-timestamp']
+      const signature = call.headers['x-nodots-signature']
+      expect(typeof timestamp).toBe('string')
+      expect(typeof signature).toBe('string')
+
+      // Signature must verify over `timestamp + '.' + body`.
+      const expected = createHmac('sha256', HMAC_SECRET)
+        .update(`${timestamp}.${call.body}`)
+        .digest('hex')
+      expect(signature).toBe(expected)
+    } finally {
+      await vendor.close()
+    }
+  })
+
+  it('reports health via GET /v1/health', async () => {
+    const health = {
+      status: 'ok',
+      engineName: 'vendor-x',
+      engineVersion: '9.9',
+      protocolVersion: '1',
+    }
+    const vendor = await startVendor(jsonReply(200, health))
+    try {
+      const provider = makeProvider(vendor.url)
+      const res = await provider.health()
+      expect(res.engineName).toBe('vendor-x')
+      expect(vendor.captured[0].method).toBe('GET')
+      expect(vendor.captured[0].url).toBe('/v1/health')
+    } finally {
+      await vendor.close()
+    }
+  })
+
+  it('throws when the API key reference resolves to nothing', async () => {
+    const vendor = await startVendor(jsonReply(200, { moves: [] }))
+    try {
+      const provider = makeProvider(vendor.url, {
+        secretResolver: () => undefined,
+      })
+      await expect(provider.getMoveHints(baseRequest())).rejects.toThrow(
+        /API key reference/
+      )
+    } finally {
+      await vendor.close()
+    }
+  })
+})

--- a/src/engine/contract.ts
+++ b/src/engine/contract.ts
@@ -15,5 +15,12 @@ export type {
   Color,
   Direction,
   Container,
+  // HTTP wire response shapes (vendor MAY omit scoring fields, so these are
+  // wider than the internal AnalysisProvider return types).
+  MoveResponse,
+  DoubleResponse,
+  TakeResponse,
+  ResignResponse,
+  HealthResponse,
 } from '@nodots/backgammon-engine-protocol'
 export { PROTOCOL_VERSION } from '@nodots/backgammon-engine-protocol'

--- a/src/engine/moveValidation.ts
+++ b/src/engine/moveValidation.ts
@@ -1,0 +1,97 @@
+/**
+ * Strict validation of a vendor-returned play against the position's legal
+ * moves.
+ *
+ * A black-box HTTP engine returns a chosen play as MoveStep[]. Before that play
+ * is trusted it must be proven legal for the position. This module delegates the
+ * match to CORE's MoveComparator.findMatchingHint (ordered / unordered / subset
+ * matching) rather than re-implementing move equivalence.
+ *
+ * No-silent-fallback rule: an unmatched vendor play THROWS with full diagnostics
+ * (positionId, dice, returned move, legal moves). It never resolves to a
+ * substitute move.
+ */
+
+import type { MoveHint, MoveStep } from './contract.js'
+
+/** from/to pair CORE's comparator matches against. */
+interface SimplifiedMove {
+  from: number
+  to: number
+}
+
+/** Diagnostic context carried into the thrown error. */
+export interface MoveValidationContext {
+  positionId: string
+  dice: [number, number]
+  engineId: string
+}
+
+/** Error thrown when a vendor play cannot be matched to a legal play. */
+export class IllegalVendorMoveError extends Error {
+  readonly positionId: string
+  readonly dice: [number, number]
+  readonly engineId: string
+  readonly returnedMove: MoveStep[]
+  readonly legalMoves: MoveHint[]
+
+  constructor(
+    context: MoveValidationContext,
+    returnedMove: MoveStep[],
+    legalMoves: MoveHint[]
+  ) {
+    const returnedStr = stepsToString(returnedMove)
+    const legalStr =
+      legalMoves.length === 0
+        ? '(none)'
+        : legalMoves.map((h) => stepsToString(h.moves)).join(' | ')
+    super(
+      `[AI] HttpEngineProvider: vendor engine "${context.engineId}" returned an ` +
+        `ILLEGAL move for position ${context.positionId} with dice ` +
+        `[${context.dice.join(',')}]. Returned=${returnedStr}. ` +
+        `Legal moves=${legalStr}. Refusing to fall back.`
+    )
+    this.name = 'IllegalVendorMoveError'
+    this.positionId = context.positionId
+    this.dice = context.dice
+    this.engineId = context.engineId
+    this.returnedMove = returnedMove
+    this.legalMoves = legalMoves
+  }
+}
+
+const stepsToString = (steps: MoveStep[]): string =>
+  steps.length === 0
+    ? '(empty)'
+    : steps.map((s) => `${s.from}/${s.to}`).join(' ')
+
+const toSimplified = (steps: MoveStep[]): SimplifiedMove[] =>
+  steps.map((s) => ({ from: s.from, to: s.to }))
+
+/**
+ * Assert a vendor play is legal for the position. Returns the matching legal
+ * MoveHint on success; throws IllegalVendorMoveError otherwise.
+ *
+ * legalMoves is the enumerated set of legal plays for the position (each a
+ * MoveHint). It is supplied by the caller -- this function does not consult any
+ * engine itself, so it stays free of the native GNU addon.
+ */
+export async function assertVendorMoveLegal(
+  returnedMove: MoveStep[],
+  legalMoves: MoveHint[],
+  context: MoveValidationContext
+): Promise<MoveHint> {
+  // Subpath import: findMatchingHint is not re-exported from the core index,
+  // and this module (MoveComparator) is pure -- it does not pull in the native
+  // gnubg addon. Lazy dynamic import mirrors robotExecution's core-import
+  // pattern for ESM/CJS interop.
+  const { findMatchingHint } = await import(
+    '@nodots/backgammon-core/dist/Services/MoveComparator.js'
+  )
+
+  const match = findMatchingHint(legalMoves, toSimplified(returnedMove))
+  if (!match) {
+    throw new IllegalVendorMoveError(context, returnedMove, legalMoves)
+  }
+  return match
+}

--- a/src/providers/HttpEngineProvider.ts
+++ b/src/providers/HttpEngineProvider.ts
@@ -1,0 +1,388 @@
+/**
+ * HttpEngineProvider
+ *
+ * Implements the language-neutral AnalysisProvider contract (src/engine/contract.ts)
+ * by calling a black-box vendor engine over HTTP:
+ *
+ *   POST /v1/move    -> getMoveHints / evaluate
+ *   POST /v1/double  -> getDoubleHint
+ *   POST /v1/take    -> getTakeHint
+ *   POST /v1/resign  -> getResignDecision
+ *   GET  /v1/health  -> health
+ *
+ * The vendor may implement its engine in any language behind this boundary and
+ * depends only on the permissive @nodots/backgammon-engine-protocol package.
+ *
+ * Guarantees enforced here:
+ *  - NO SILENT FALLBACK. Timeout, network error, or non-2xx status throws a
+ *    diagnostic error. It never substitutes a GNU move or a default move.
+ *  - Strict move validation. A configured legalMoveResolver enumerates the legal
+ *    plays for a position; the vendor's chosen play is matched against them via
+ *    assertVendorMoveLegal, which throws with full diagnostics on any mismatch.
+ *  - Optional HMAC request signing (X-Nodots-Timestamp + X-Nodots-Signature).
+ *  - Hard timeout ceiling: the effective per-request timeout is
+ *    min(config.timeoutMs, HARD_TIMEOUT_MS) enforced via AbortController.
+ */
+
+import { createHmac } from 'node:crypto'
+import type {
+  AnalysisProvider,
+  DoubleHint,
+  DoubleResponse,
+  Evaluation,
+  Explanation,
+  HealthResponse,
+  HealthStatus,
+  HintRequest,
+  MoveHint,
+  MoveResponse,
+  ResignDecision,
+  ResignResponse,
+  TakeHint,
+  TakeResponse,
+} from '../engine/contract.js'
+import { assertVendorMoveLegal } from '../engine/moveValidation.js'
+
+/** Default per-request budget (ms). */
+const DEFAULT_TIMEOUT_MS = 2_000
+/** Absolute ceiling on any single request (ms). */
+const HARD_TIMEOUT_MS = 10_000
+
+/** Resolves a secret reference (e.g. an env-var name) to its value. */
+export type SecretResolver = (ref: string) => string | undefined
+
+/**
+ * Enumerates the legal plays for a position, used ONLY to validate the vendor's
+ * returned play. Supplied by the caller so the provider carries no dependency on
+ * the native GNU addon. When omitted, move validation is skipped (the caller is
+ * then responsible for validating downstream).
+ */
+export type LegalMoveResolver = (req: HintRequest) => Promise<MoveHint[]>
+
+export interface HttpEngineProviderConfig {
+  /** Vendor base URL, e.g. https://engine.vendor.example (no trailing /v1). */
+  baseUrl: string
+  /** Reference to the API key secret (resolved via secretResolver). */
+  apiKeyRef: string
+  /** Stable identifier for this vendor engine, sent as X-Nodots-Engine-Id. */
+  engineId: string
+  /** Per-request budget in ms. Clamped to <= HARD_TIMEOUT_MS. Default 2000. */
+  timeoutMs?: number
+  /** Reference to the HMAC signing secret. When set, requests are signed. */
+  hmacSecretRef?: string
+  /** Secret-reference resolver. Default: read process.env[ref]. */
+  secretResolver?: SecretResolver
+  /** Legal-move enumerator for strict validation. */
+  legalMoveResolver?: LegalMoveResolver
+  /** fetch implementation. Default: global fetch. Injectable for tests. */
+  fetchImpl?: typeof fetch
+}
+
+const defaultSecretResolver: SecretResolver = (ref) => process.env[ref]
+
+export class HttpEngineProvider implements AnalysisProvider {
+  private readonly baseUrl: string
+  private readonly apiKeyRef: string
+  private readonly engineId: string
+  private readonly timeoutMs: number
+  private readonly hmacSecretRef?: string
+  private readonly secretResolver: SecretResolver
+  private readonly legalMoveResolver?: LegalMoveResolver
+  private readonly fetchImpl: typeof fetch
+
+  constructor(config: HttpEngineProviderConfig) {
+    // Strip a trailing slash so `${baseUrl}/v1/...` never doubles up.
+    this.baseUrl = config.baseUrl.replace(/\/+$/, '')
+    this.apiKeyRef = config.apiKeyRef
+    this.engineId = config.engineId
+    this.timeoutMs = Math.min(
+      config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      HARD_TIMEOUT_MS
+    )
+    this.hmacSecretRef = config.hmacSecretRef
+    this.secretResolver = config.secretResolver ?? defaultSecretResolver
+    this.legalMoveResolver = config.legalMoveResolver
+    this.fetchImpl = config.fetchImpl ?? fetch
+  }
+
+  /**
+   * Return ranked move hints for the position. Calls POST /v1/move, then (when a
+   * legalMoveResolver is configured) validates the vendor's chosen play against
+   * the enumerated legal plays. Throws on an illegal play -- never substitutes.
+   */
+  async getMoveHints(req: HintRequest, maxHints?: number): Promise<MoveHint[]> {
+    const body = this.buildRequestBody(req, { includeDice: true, maxHints })
+    const res = await this.post<MoveResponse>('/v1/move', body)
+
+    if (!Array.isArray(res.moves)) {
+      throw new Error(
+        `[AI] HttpEngineProvider: vendor "${this.engineId}" returned no moves ` +
+          `array for position ${req.positionId}. Body=${JSON.stringify(res)}`
+      )
+    }
+
+    if (this.legalMoveResolver) {
+      const legalMoves = await this.legalMoveResolver(req)
+      // Throws IllegalVendorMoveError with full diagnostics on mismatch.
+      await assertVendorMoveLegal(res.moves, legalMoves, {
+        positionId: req.positionId,
+        dice: req.dice,
+        engineId: this.engineId,
+      })
+    }
+
+    // Prefer the vendor's ranked candidates when present; otherwise synthesize a
+    // single hint from the chosen play so callers always receive MoveHint[].
+    if (Array.isArray(res.candidates) && res.candidates.length > 0) {
+      return typeof maxHints === 'number'
+        ? res.candidates.slice(0, maxHints)
+        : res.candidates
+    }
+    return [this.synthesizeHint(res)]
+  }
+
+  /**
+   * Position evaluation, derived from the top-ranked move hint (mirrors
+   * InProcessGnuProvider). Throws when the position yields no move.
+   */
+  async evaluate(req: HintRequest): Promise<Evaluation> {
+    const hints = await this.getMoveHints(req, 1)
+    if (!hints || hints.length === 0) {
+      throw new Error(
+        `[AI] HttpEngineProvider.evaluate: no hints returned for position ${req.positionId}`
+      )
+    }
+    return hints[0].evaluation
+  }
+
+  async getDoubleHint(req: HintRequest): Promise<DoubleHint> {
+    // Cube decisions carry no meaningful dice (see protocol SPEC).
+    const body = this.buildRequestBody(req, { includeDice: false })
+    const res = await this.post<DoubleResponse>('/v1/double', body)
+    // evaluation is not a top-level wire field; it rides on the top candidate
+    // when the vendor exposes scoring. Source it there, never fabricate it.
+    const top = res.candidates?.[0]
+    return {
+      action: res.action,
+      takePoint: requireNumber(
+        res.takePoint ?? top?.takePoint,
+        'double.takePoint',
+        this.engineId
+      ),
+      dropPoint: requireNumber(
+        res.dropPoint ?? top?.dropPoint,
+        'double.dropPoint',
+        this.engineId
+      ),
+      evaluation: requireEvaluation(top?.evaluation, 'double', this.engineId),
+      cubefulEquity: requireNumber(
+        res.equity ?? top?.cubefulEquity,
+        'double.equity',
+        this.engineId
+      ),
+    }
+  }
+
+  async getTakeHint(req: HintRequest): Promise<TakeHint> {
+    const body = this.buildRequestBody(req, { includeDice: false })
+    const res = await this.post<TakeResponse>('/v1/take', body)
+    const top = res.candidates?.[0]
+    return {
+      action: res.action,
+      evaluation: requireEvaluation(top?.evaluation, 'take', this.engineId),
+      takeEquity: requireNumber(
+        res.takeEquity ?? top?.takeEquity,
+        'take.takeEquity',
+        this.engineId
+      ),
+      dropEquity: requireNumber(
+        res.dropEquity ?? top?.dropEquity,
+        'take.dropEquity',
+        this.engineId
+      ),
+    }
+  }
+
+  async getResignDecision(req: HintRequest): Promise<ResignDecision> {
+    const body = this.buildRequestBody(req, { includeDice: false })
+    const res = await this.post<ResignResponse>('/v1/resign', body)
+    return { action: res.action }
+  }
+
+  async explain(_req: HintRequest): Promise<Explanation> {
+    // No /v1/explain surface in the protocol response set. Refuse to fabricate.
+    throw new Error(
+      `[AI] HttpEngineProvider.explain is not supported: the vendor HTTP ` +
+        `surface exposes no explain endpoint.`
+    )
+  }
+
+  async health(): Promise<HealthStatus> {
+    const res = await this.get<HealthResponse>('/v1/health')
+    return res
+  }
+
+  // --- internals -----------------------------------------------------------
+
+  private synthesizeHint(res: MoveResponse): MoveHint {
+    const equity = typeof res.equity === 'number' ? res.equity : 0
+    const emptyEvaluation: Evaluation = {
+      win: 0,
+      winGammon: 0,
+      winBackgammon: 0,
+      loseGammon: 0,
+      loseBackgammon: 0,
+      equity,
+    }
+    return {
+      moves: res.moves,
+      evaluation: emptyEvaluation,
+      equity,
+      rank: 0,
+      difference: 0,
+    }
+  }
+
+  private buildRequestBody(
+    req: HintRequest,
+    opts: { includeDice: boolean; maxHints?: number }
+  ): Record<string, unknown> {
+    const { dice, ...rest } = req
+    const base: Record<string, unknown> = {
+      ...rest,
+      engineId: this.engineId,
+    }
+    if (opts.includeDice) base.dice = dice
+    if (typeof opts.maxHints === 'number') base.maxHints = opts.maxHints
+    return base
+  }
+
+  private async post<T>(
+    path: string,
+    body: Record<string, unknown>
+  ): Promise<T> {
+    return this.request<T>('POST', path, JSON.stringify(body))
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    return this.request<T>('GET', path, undefined)
+  }
+
+  private async request<T>(
+    method: 'GET' | 'POST',
+    path: string,
+    body: string | undefined
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+
+    let res: Response
+    try {
+      res = await this.fetchImpl(url, {
+        method,
+        headers: this.buildHeaders(body ?? ''),
+        body,
+        signal: controller.signal,
+      })
+    } catch (err) {
+      const aborted =
+        controller.signal.aborted ||
+        (err instanceof Error && err.name === 'AbortError')
+      if (aborted) {
+        throw new Error(
+          `[AI] HttpEngineProvider: vendor "${this.engineId}" ${method} ${url} ` +
+            `timed out after ${this.timeoutMs}ms. Refusing to fall back.`
+        )
+      }
+      throw new Error(
+        `[AI] HttpEngineProvider: vendor "${this.engineId}" ${method} ${url} ` +
+          `network error: ${err instanceof Error ? err.message : String(err)}. ` +
+          `Refusing to fall back.`
+      )
+    } finally {
+      clearTimeout(timer)
+    }
+
+    if (!res.ok) {
+      const text = await safeText(res)
+      throw new Error(
+        `[AI] HttpEngineProvider: vendor "${this.engineId}" ${method} ${url} ` +
+          `returned HTTP ${res.status}. Body=${text}. Refusing to fall back.`
+      )
+    }
+
+    return (await res.json()) as T
+  }
+
+  private buildHeaders(body: string): Record<string, string> {
+    const apiKey = this.secretResolver(this.apiKeyRef)
+    if (!apiKey) {
+      throw new Error(
+        `[AI] HttpEngineProvider: API key reference "${this.apiKeyRef}" ` +
+          `resolved to no value. Cannot authenticate to vendor "${this.engineId}".`
+      )
+    }
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      'X-Nodots-Engine-Id': this.engineId,
+    }
+
+    if (this.hmacSecretRef) {
+      const secret = this.secretResolver(this.hmacSecretRef)
+      if (!secret) {
+        throw new Error(
+          `[AI] HttpEngineProvider: HMAC secret reference "${this.hmacSecretRef}" ` +
+            `resolved to no value. Cannot sign requests to vendor "${this.engineId}".`
+        )
+      }
+      const timestamp = Date.now().toString()
+      const signature = createHmac('sha256', secret)
+        .update(`${timestamp}.${body}`)
+        .digest('hex')
+      headers['X-Nodots-Timestamp'] = timestamp
+      headers['X-Nodots-Signature'] = signature
+    }
+
+    return headers
+  }
+}
+
+const requireNumber = (
+  value: number | undefined,
+  field: string,
+  engineId: string
+): number => {
+  if (typeof value !== 'number') {
+    throw new Error(
+      `[AI] HttpEngineProvider: vendor "${engineId}" omitted required numeric ` +
+        `field "${field}". Refusing to fabricate a value.`
+    )
+  }
+  return value
+}
+
+const requireEvaluation = (
+  evaluation: Evaluation | undefined,
+  method: string,
+  engineId: string
+): Evaluation => {
+  if (!evaluation) {
+    throw new Error(
+      `[AI] HttpEngineProvider: vendor "${engineId}" omitted required ` +
+        `"evaluation" for ${method}. Refusing to fabricate a value.`
+    )
+  }
+  return evaluation
+}
+
+const safeText = async (res: Response): Promise<string> => {
+  try {
+    return await res.text()
+  } catch {
+    return '(unreadable body)'
+  }
+}


### PR DESCRIPTION
## C1.2 — HttpEngineProvider

Implements the language-neutral `AnalysisProvider` contract for **black-box HTTP engines**, calling `POST /v1/{move,double,take,resign}` + `GET /v1/health` on a vendor endpoint. Sibling of C1.1's `InProcessGnuProvider`.

Refs nodots/backgammon#367.

### What's here
- `src/providers/HttpEngineProvider.ts` — HTTP client provider.
  - Config `{ baseUrl, apiKeyRef, timeoutMs, engineId, hmacSecretRef?, secretResolver?, legalMoveResolver?, fetchImpl? }`. Per-request budget defaults to **2s**, hard-capped at **10s** via `AbortController`.
  - Optional **HMAC signing**: `X-Nodots-Timestamp` + `X-Nodots-Signature` = HMAC-SHA256 over `timestamp + '.' + body`, emitted only when `hmacSecretRef` resolves.
  - **No silent fallback**: timeout / non-2xx (incl. 5xx) / network error each throw a diagnostic error. Never substitutes a GNU or default move.
  - Secret *refs* resolve via an injectable `secretResolver` (default `process.env[ref]`).
- `src/engine/moveValidation.ts` — `assertVendorMoveLegal` + `IllegalVendorMoveError`. Delegates matching to CORE `MoveComparator.findMatchingHint` (subpath import; pure, no native addon) and throws with full diagnostics (positionId, dice, returned move, legal moves) on any mismatch.
- `src/engine/contract.ts` — adds `MoveResponse/DoubleResponse/TakeResponse/ResignResponse/HealthResponse` to the single-site re-export.
- `src/__tests__/http-engine-provider.test.ts` — 9 tests against an **in-process `http.Server` mock vendor** (no fetch mock): move round-trip, synthesized single-hint, illegal-move throw w/ diagnostics, timeout throw, 5xx throw, network-error throw, HMAC header verify, health GET, missing-API-key throw.

### Verification
Build: `npm run build` → exit 0 (clean).

**No regression** — failing-suite set is byte-identical to `origin/development` baseline (all 8 are pre-existing native-addon suites):

Baseline (`origin/development`, HEAD `3846b53`) — `Test Suites: 8 failed, 3 skipped, 7 passed`:
```
FAIL bar-reentry-dice-bug   FAIL gbg-bot-failure       FAIL gnu-nodots-roundtrip
FAIL index                  FAIL pid-orientation-original  FAIL position-matcher
FAIL robot-hint-arguments   FAIL robot-reentry-no-move
```

After this branch — `Test Suites: 8 failed, 3 skipped, 8 passed`:
```
(same 8 FAIL suites)  +  PASS http-engine-provider (9/9)
```
Failing set unchanged; this branch adds one passing suite (`http-engine-provider`, 9 tests) and adds zero failures.

### Stayed in lane
No changes to `robotExecution.ts`, `package.json`, `tsconfig.json`, or `.github/**`.
