### PR TITLE
[READY]: C2.7B — NeuralAIProvider host adapter

### DIFF
--- a/src/__tests__/neural-ai-provider.test.ts
+++ b/src/__tests__/neural-ai-provider.test.ts
@@ -1,0 +1,263 @@
+/**
+ * NeuralAIProvider tests.
+ *
+ * Proves the host adapter drives a robot turn by talking to the neural /v1
+ * service over HTTP (a real in-process mock server, no fetch mock) through
+ * HttpEngineProvider, with the vendor play validated against CORE's enumerated
+ * legal plays (legalMoveResolver) before any step executes.
+ *
+ * CORE is mocked (Board move-gen/apply, Game execution, positionId export) the
+ * same way the GNU robot-execution tests mock it, so the test is hermetic and
+ * exercises the adapter's wiring, enumeration, and no-silent-fallback contract
+ * without a live CORE game or the native addon.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals'
+import http from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+// Force ESM emit so the top-level `await import` below is valid (ts-jest hybrid
+// mode otherwise transforms some files to CJS, where top-level await is illegal).
+export {}
+
+// --- CORE mock -------------------------------------------------------------
+
+// A minimal board carries a tag so the move-generation mock can return the
+// right single-die steps for each intermediate board during enumeration.
+type MockBoard = { _tag: string }
+
+const point = (id: string, pos: number) => ({
+  id,
+  kind: 'point',
+  position: { clockwise: pos, counterclockwise: pos },
+})
+// Single-die legal steps keyed by (boardTag, die). The opening 8/5 6/5 for a
+// [3,1] roll: die 3 plays 8->5, die 1 plays 6->5, in either order.
+const skeleton = (fromPos: number, toPos: number, die: number) => ({
+  origin: point(`p${fromPos}`, fromPos),
+  destination: point(`p${toPos}`, toPos),
+  dieValue: die,
+  direction: 'clockwise',
+})
+const STEPS: Record<string, ReturnType<typeof skeleton>[]> = {
+  'start|3': [skeleton(8, 5, 3)],
+  'start|1': [skeleton(6, 5, 1)],
+  'start>p8|1': [skeleton(6, 5, 1)],
+  'start>p6|3': [skeleton(8, 5, 3)],
+}
+
+const getPossibleMovesMock = jest.fn(
+  (board: MockBoard, _player: unknown, die: number) =>
+    STEPS[`${board._tag}|${die}`] ?? [],
+)
+const moveCheckerMock = jest.fn(
+  (board: MockBoard, origin: { id: string }): MockBoard => ({
+    _tag: `${board._tag}>${origin.id}`,
+  }),
+)
+
+// Execution advances a small state machine: first origin (p8) leaves the die-1
+// move ready; second (p6) empties the turn.
+const executeAndRecalculateMock = jest.fn(
+  (game: any, originId: string): any => {
+    if (originId === 'p8') {
+      return {
+        ...game,
+        board: { _tag: 'start>p8' },
+        activePlay: { ...game.activePlay, moves: [readyMove(6, 5, 1)] },
+        stateKind: 'moving',
+      }
+    }
+    return {
+      ...game,
+      board: { _tag: 'done' },
+      activePlay: { ...game.activePlay, moves: [] },
+      stateKind: 'moving',
+    }
+  },
+)
+const checkAndCompleteTurnMock = jest.fn((game: any) => ({
+  ...game,
+  stateKind: 'rolling',
+}))
+const exportToGnuPositionIdMock = jest.fn(() => '4HPwATDgc/ABMA')
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+}
+
+jest.unstable_mockModule('@nodots/backgammon-core', () => ({
+  Board: {
+    getPossibleMoves: getPossibleMovesMock,
+    moveChecker: moveCheckerMock,
+  },
+  Game: {
+    executeAndRecalculate: executeAndRecalculateMock,
+    checkAndCompleteTurn: checkAndCompleteTurnMock,
+  },
+  exportToGnuPositionId: exportToGnuPositionIdMock,
+  logger: noopLogger,
+}))
+
+// A ready move whose possibleMoves match a single-die step (refreshed each
+// iteration by the getPossibleMoves mock, but seeded here too).
+function readyMove(fromPos: number, toPos: number, die: number) {
+  return {
+    id: `move-${die}`,
+    stateKind: 'ready',
+    dieValue: die,
+    moveKind: 'point-to-point',
+    possibleMoves: [skeleton(fromPos, toPos, die)],
+  }
+}
+
+// Top-level await import so the SUT's lazy `import('@nodots/backgammon-core')`
+// binds to the mock registered above (same pattern the GNU robot-execution
+// tests use). `export {}` below forces ESM emit under ts-jest hybrid mode.
+const { NeuralAIProvider } = await import('../providers/NeuralAIProvider.js')
+
+// --- mock neural /v1 server ------------------------------------------------
+
+interface MockServer {
+  url: string
+  captured: { method: string; url: string; body: string }[]
+  close: () => Promise<void>
+}
+async function startServer(
+  handler: (body: string, res: http.ServerResponse) => void,
+): Promise<MockServer> {
+  const captured: MockServer['captured'] = []
+  const server = http.createServer((req, res) => {
+    const chunks: Buffer[] = []
+    req.on('data', (c) => chunks.push(c as Buffer))
+    req.on('end', () => {
+      const body = Buffer.concat(chunks).toString('utf8')
+      captured.push({ method: req.method ?? '', url: req.url ?? '', body })
+      handler(body, res)
+    })
+  })
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r))
+  const { port } = server.address() as AddressInfo
+  return {
+    url: `http://127.0.0.1:${port}`,
+    captured,
+    close: () =>
+      new Promise<void>((resolve, reject) =>
+        server.close((e) => (e ? reject(e) : resolve())),
+      ),
+  }
+}
+
+const moveStep = (from: number, to: number) => ({
+  from,
+  to,
+  moveKind: 'point-to-point',
+  isHit: false,
+  player: 'white',
+  fromContainer: 'point',
+  toContainer: 'point',
+})
+
+function makeGame() {
+  const activePlayer = {
+    id: 'p1',
+    color: 'white',
+    direction: 'clockwise',
+    isRobot: true,
+  }
+  return {
+    id: 'g1',
+    stateKind: 'moving',
+    board: { _tag: 'start' } as MockBoard,
+    activePlayer,
+    activePlay: {
+      id: 'ap1',
+      player: activePlayer,
+      moves: [readyMove(8, 5, 3), readyMove(6, 5, 1)],
+    },
+  }
+}
+
+// --- tests -----------------------------------------------------------------
+
+describe('NeuralAIProvider', () => {
+  const servers: MockServer[] = []
+  beforeEach(() => {
+    process.env.NEURAL_ENGINE_API_KEY = 'test-key'
+    jest.clearAllMocks()
+  })
+  afterAll(async () => {
+    for (const s of servers) await s.close()
+  })
+
+  it('drives a full turn: fetches the play over HTTP and executes it via CORE', async () => {
+    const server = await startServer((_body, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(
+        JSON.stringify({
+          moves: [moveStep(8, 5), moveStep(6, 5)],
+          equity: 0.1,
+          candidates: [
+            {
+              moves: [moveStep(8, 5), moveStep(6, 5)],
+              evaluation: {
+                win: 0.5,
+                winGammon: 0,
+                winBackgammon: 0,
+                loseGammon: 0,
+                loseBackgammon: 0,
+                equity: 0.1,
+              },
+              equity: 0.1,
+              rank: 1,
+              difference: 0,
+            },
+          ],
+        }),
+      )
+    })
+    servers.push(server)
+
+    const provider = new NeuralAIProvider({ baseUrl: server.url })
+    const result = await provider.executeRobotTurn(makeGame() as any)
+
+    // The request hit the neural /v1/move endpoint with the exported positionId.
+    expect(server.captured[0].method).toBe('POST')
+    expect(server.captured[0].url).toBe('/v1/move')
+    expect(JSON.parse(server.captured[0].body).positionId).toBe('4HPwATDgc/ABMA')
+    // Both planned steps executed through CORE, in order.
+    expect(executeAndRecalculateMock.mock.calls.map((c) => c[1])).toEqual([
+      'p8',
+      'p6',
+    ])
+    // Turn finished in rolling state.
+    expect(result.stateKind).toBe('rolling')
+  })
+
+  it('throws (no silent fallback) when the engine returns an illegal play', async () => {
+    const server = await startServer((_body, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      // 13/2 is not among CORE's enumerated legal plays for this position.
+      res.end(JSON.stringify({ moves: [moveStep(13, 2)] }))
+    })
+    servers.push(server)
+
+    const provider = new NeuralAIProvider({ baseUrl: server.url })
+    await expect(
+      provider.executeRobotTurn(makeGame() as any),
+    ).rejects.toThrow(/ILLEGAL move|Refusing to fall back/)
+    // No move was executed.
+    expect(executeAndRecalculateMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses to run for a non-robot active player', async () => {
+    const provider = new NeuralAIProvider({ baseUrl: 'http://127.0.0.1:1' })
+    const game = makeGame() as any
+    game.activePlayer.isRobot = false
+    await expect(provider.executeRobotTurn(game)).rejects.toThrow(
+      /to be a robot/,
+    )
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,12 @@ export async function registerAIProvider(): Promise<void> {
   const { GNUAIProvider } = await import('./GNUAIProvider.js');
   const { NodotsAIProvider } = await import('./NodotsAIProvider.js');
   const { TeaLeavesAIProvider } = await import('./TeaLeavesAIProvider.js');
+  const { NeuralAIProvider } = await import('./providers/NeuralAIProvider.js');
 
   const gnuProvider = new GNUAIProvider();
   const nodotsProvider = new NodotsAIProvider();
   const teaLeavesProvider = new TeaLeavesAIProvider();
+  const neuralProvider = new NeuralAIProvider();
 
   // GNU robots: matched by email prefix from seed-robots.ts
   RobotAIRegistry.register('gnu-*', gnuProvider);
@@ -33,6 +35,8 @@ export async function registerAIProvider(): Promise<void> {
   RobotAIRegistry.register('nbg-*', nodotsProvider);
   // Tea Leaves: calibration-floor provider that picks by hashing position id
   RobotAIRegistry.register('tea-*', teaLeavesProvider);
+  // Nodots neural engine, reached over the /v1 HTTP protocol via HttpEngineProvider
+  RobotAIRegistry.register('nn-*', neuralProvider);
   // Fallback for any unrecognized robot
   RobotAIRegistry.register('*', nodotsProvider);
 
@@ -115,6 +119,7 @@ export * from './hintContext.js';
 // Export AI provider implementations
 export { GNUAIProvider } from './GNUAIProvider.js';
 export { NodotsAIProvider } from './NodotsAIProvider.js';
+export { NeuralAIProvider } from './providers/NeuralAIProvider.js';
 export { executeRobotTurnWithGNU } from './robotExecution.js';
 
 // Engine boundary: AnalysisProvider contract + in-process GNU implementation.

--- a/src/providers/NeuralAIProvider.ts
+++ b/src/providers/NeuralAIProvider.ts
@@ -1,0 +1,393 @@
+/**
+ * NeuralAIProvider
+ *
+ * Host-side RobotAIProvider for the first-party Nodots neural engine. It drives a
+ * complete robot turn by talking to the neural /v1 HTTP service (the same
+ * black-box AnalysisProvider contract the reference vendor implements) through
+ * HttpEngineProvider, then executes the returned play against CORE.
+ *
+ * Two boundaries are honored:
+ *  - The neural engine is reached ONLY over HTTP via HttpEngineProvider. No
+ *    in-process neural code is imported here; the engine stays a swappable
+ *    plugin behind @nodots/backgammon-engine-protocol.
+ *  - NO SILENT FALLBACK (CLAUDE.md). The vendor play is validated against CORE's
+ *    enumerated legal plays (legalMoveResolver) inside HttpEngineProvider, and
+ *    each executed step is re-matched to a CORE ready move; an unmatched step
+ *    throws with diagnostics rather than substituting a different move.
+ *
+ * Registered under the `nn-*@nodots.com` robot email prefix in RobotAIRegistry.
+ */
+
+import type {
+  BackgammonColor,
+  BackgammonDieValue,
+  BackgammonGameMoving,
+  BackgammonGameRolling,
+  BackgammonMoveDirection,
+  BackgammonMoveReady,
+  BackgammonMoveSkeleton,
+  BackgammonPlayMoving,
+  BackgammonPlayer,
+} from '@nodots/backgammon-types'
+import type { RobotAIProvider } from '@nodots/backgammon-core'
+import type { HintRequest, MoveHint, MoveStep } from '../engine/contract.js'
+import {
+  HttpEngineProvider,
+  type HttpEngineProviderConfig,
+  type LegalMoveResolver,
+} from './HttpEngineProvider.js'
+
+// Lazy CORE imports mirror robotExecution's pattern: break the ai<->core cycle
+// and keep the module importable without eagerly loading CORE.
+let Core: any = null
+let Board: any = null
+let exportToGnuPositionIdFn: any = null
+const getCore = async (): Promise<any> => {
+  if (!Core) Core = await import('@nodots/backgammon-core')
+  return Core
+}
+const getBoard = async (): Promise<any> => {
+  if (!Board) Board = (await getCore()).Board
+  return Board
+}
+const getExportToGnuPositionId = async (): Promise<
+  (game: BackgammonGameMoving) => string
+> => {
+  if (!exportToGnuPositionIdFn) {
+    exportToGnuPositionIdFn = (await getCore()).exportToGnuPositionId
+  }
+  return exportToGnuPositionIdFn
+}
+
+// matchStepToReadyMove lives in robotExecution (forbidden to edit, safe to
+// import). It matches a plan step to a CORE ready move by origin/destination
+// position and die, the same validation the GNU path uses.
+let matchStepToReadyMoveFn:
+  | ((
+      step: MoveStep,
+      ready: unknown[],
+      dir: BackgammonMoveDirection,
+      mappedOriginId: string | null,
+    ) => {
+      matched: boolean
+      originId: string | null
+      desiredDestinationId: string | null
+      matchedDie?: number
+    })
+  | null = null
+const getMatchStepToReadyMove = async (): Promise<
+  NonNullable<typeof matchStepToReadyMoveFn>
+> => {
+  if (!matchStepToReadyMoveFn) {
+    const mod = await import('../robotExecution.js')
+    matchStepToReadyMoveFn = mod.matchStepToReadyMove
+  }
+  return matchStepToReadyMoveFn
+}
+
+/** Default location of the neural /v1 service; override with NEURAL_ENGINE_URL. */
+const DEFAULT_ENGINE_URL = 'http://127.0.0.1:8080'
+const ENGINE_ID = 'nodots-neural'
+/** Loop ceiling: a turn is at most four steps (doubles); guard against cycles. */
+const TURN_GUARD = 8
+
+/** Map a CORE possibleMove skeleton to a protocol MoveStep (mover's numbering). */
+function skeletonToStep(
+  skeleton: BackgammonMoveSkeleton,
+  direction: BackgammonMoveDirection,
+): MoveStep {
+  const { origin, destination } = skeleton
+  const fromBar = origin.kind === 'bar'
+  const toOff = destination.kind === 'off'
+  // Protocol convention: bar is from=0, off is to=0 (matches the neural engine's
+  // KernelPosition encoding). Points carry their own directional position.
+  const from = fromBar ? 0 : (origin.position as Record<string, number>)[direction]
+  const to = toOff ? 0 : (destination.position as Record<string, number>)[direction]
+  const moveKind = fromBar ? 'reenter' : toOff ? 'bear-off' : 'point-to-point'
+  return {
+    from,
+    to,
+    moveKind,
+    isHit: false,
+    // player color is not consulted by findMatchingHint; fill from direction.
+    player: direction === 'clockwise' ? 'white' : 'black',
+    fromContainer: fromBar ? 'bar' : 'point',
+    toContainer: toOff ? 'off' : 'point',
+  }
+}
+
+/** A play threaded through the enumeration DFS. */
+interface EnumeratedPlay {
+  steps: MoveStep[]
+  board: unknown
+}
+
+/** Order-sensitive key for a play's from/to sequence. */
+function playKey(steps: readonly MoveStep[]): string {
+  return steps.map((s) => `${s.from}/${s.to}`).join(',')
+}
+
+export interface NeuralProviderOptions {
+  /** Base URL of the neural /v1 service. Default: NEURAL_ENGINE_URL or localhost. */
+  baseUrl?: string
+  /** Env-var name holding the API key. Default: NEURAL_ENGINE_API_KEY. */
+  apiKeyRef?: string
+  /** Env-var name holding the HMAC signing secret (optional). */
+  hmacSecretRef?: string
+  /** Per-request timeout (ms). */
+  timeoutMs?: number
+}
+
+export class NeuralAIProvider implements RobotAIProvider {
+  private readonly baseUrl: string
+  private readonly apiKeyRef: string
+  private readonly hmacSecretRef?: string
+  private readonly timeoutMs?: number
+
+  constructor(options: NeuralProviderOptions = {}) {
+    this.baseUrl =
+      options.baseUrl ?? process.env.NEURAL_ENGINE_URL ?? DEFAULT_ENGINE_URL
+    this.apiKeyRef = options.apiKeyRef ?? 'NEURAL_ENGINE_API_KEY'
+    this.hmacSecretRef = options.hmacSecretRef ?? process.env.NEURAL_ENGINE_HMAC_REF
+    this.timeoutMs = options.timeoutMs
+  }
+
+  /**
+   * Enumerate CORE's legal FULL plays for a moving game as protocol MoveHint[].
+   * Composes single-die legal steps (Board.getPossibleMoves) into full turns via
+   * Board.moveChecker, applying backgammon's use-max-dice and higher-die rules.
+   * This is the CORE-enumeration source HttpEngineProvider validates against.
+   */
+  private async enumerateLegalPlays(
+    game: BackgammonGameMoving,
+  ): Promise<MoveHint[]> {
+    const BoardUtil = await getBoard()
+    const player = game.activePlayer as BackgammonPlayer
+    const direction = player.direction
+    const ready = (game.activePlay?.moves ?? []).filter(
+      (m: { stateKind: string }) => m.stateKind === 'ready',
+    ) as BackgammonMoveReady[]
+    const d1 = (ready[0]?.dieValue ?? 1) as BackgammonDieValue
+    const d2 = (ready[1]?.dieValue ?? d1) as BackgammonDieValue
+
+    // Doubles are a single ordered sequence of four; a non-double is tried both
+    // orders because each can reach turns the other cannot.
+    const sequences: BackgammonDieValue[][] =
+      d1 === d2 ? [[d1, d1, d1, d1]] : [
+        [d1, d2],
+        [d2, d1],
+      ]
+
+    const terminals: EnumeratedPlay[] = []
+    const walk = (
+      board: unknown,
+      remaining: BackgammonDieValue[],
+      steps: MoveStep[],
+    ): void => {
+      if (remaining.length === 0) {
+        terminals.push({ steps, board })
+        return
+      }
+      const [face, ...rest] = remaining
+      const skeletons = BoardUtil.getPossibleMoves(
+        board,
+        player,
+        face,
+      ) as BackgammonMoveSkeleton[]
+      if (skeletons.length === 0) {
+        terminals.push({ steps, board })
+        return
+      }
+      for (const skeleton of skeletons) {
+        const nextBoard = BoardUtil.moveChecker(
+          board,
+          skeleton.origin,
+          skeleton.destination,
+          direction,
+        )
+        walk(nextBoard, rest, [...steps, skeletonToStep(skeleton, direction)])
+      }
+    }
+    for (const seq of sequences) walk(game.board, seq, [])
+
+    const maxSteps = terminals.reduce((m, t) => Math.max(m, t.steps.length), 0)
+    let kept = terminals.filter((t) => t.steps.length === maxSteps)
+    // Higher-die rule: when only one die is playable, a play using the larger
+    // die makes any smaller-die-only play illegal.
+    if (maxSteps === 1 && d1 !== d2) {
+      const larger = Math.max(d1, d2)
+      const usesLarger = (t: EnumeratedPlay): boolean => {
+        const s = t.steps[0]
+        const die =
+          s.moveKind === 'reenter'
+            ? 25 - s.to
+            : s.moveKind === 'bear-off'
+              ? undefined
+              : s.from - s.to
+        return die === larger
+      }
+      if (kept.some(usesLarger)) kept = kept.filter(usesLarger)
+    }
+
+    // De-dupe by play key and wrap as MoveHints. Evaluation is a placeholder:
+    // findMatchingHint consumes only `moves`, never the equity fields.
+    const seen = new Set<string>()
+    const hints: MoveHint[] = []
+    for (const t of kept) {
+      const key = playKey(t.steps)
+      if (seen.has(key)) continue
+      seen.add(key)
+      hints.push({
+        moves: t.steps,
+        evaluation: {
+          win: 0,
+          winGammon: 0,
+          winBackgammon: 0,
+          loseGammon: 0,
+          loseBackgammon: 0,
+          equity: 0,
+        },
+        equity: 0,
+        rank: hints.length + 1,
+        difference: 0,
+      })
+    }
+    return hints
+  }
+
+  /** Build an HttpEngineProvider whose legalMoveResolver enumerates CORE plays. */
+  private buildProvider(game: BackgammonGameMoving): HttpEngineProvider {
+    const legalMoveResolver: LegalMoveResolver = async () =>
+      this.enumerateLegalPlays(game)
+    const config: HttpEngineProviderConfig = {
+      baseUrl: this.baseUrl,
+      apiKeyRef: this.apiKeyRef,
+      engineId: ENGINE_ID,
+      legalMoveResolver,
+      ...(this.hmacSecretRef ? { hmacSecretRef: this.hmacSecretRef } : {}),
+      ...(typeof this.timeoutMs === 'number' ? { timeoutMs: this.timeoutMs } : {}),
+    }
+    return new HttpEngineProvider(config)
+  }
+
+  /** Build the positionId-based HintRequest for the current game + roll. */
+  private async buildHintRequest(
+    game: BackgammonGameMoving,
+  ): Promise<HintRequest> {
+    const exportPid = await getExportToGnuPositionId()
+    const positionId = exportPid(game)
+    const ready = (game.activePlay?.moves ?? []).filter(
+      (m: { stateKind: string }) => m.stateKind === 'ready',
+    ) as BackgammonMoveReady[]
+    const d1 = (ready[0]?.dieValue ?? 1) as BackgammonDieValue
+    const d2 = (ready[1]?.dieValue ?? d1) as BackgammonDieValue
+    const player = game.activePlayer as BackgammonPlayer
+    return {
+      positionId,
+      dice: [d1, d2],
+      activePlayerColor: player.color as BackgammonColor,
+      activePlayerDirection: player.direction,
+      cubeValue: 1,
+      cubeOwner: null,
+      matchScore: [0, 0],
+      matchLength: 0,
+      crawford: false,
+      jacoby: false,
+      beavers: false,
+    }
+  }
+
+  /**
+   * Execute a full robot turn: fetch the neural engine's play (validated legal
+   * against CORE), then apply it step by step through CORE. Each step is matched
+   * to a CORE ready move; an unmatched step throws (no silent fallback).
+   */
+  async executeRobotTurn(
+    game: BackgammonGameMoving,
+  ): Promise<BackgammonGameRolling> {
+    if (!game.activePlayer.isRobot) {
+      throw new Error(
+        `NeuralAIProvider requires active player to be a robot, but got isRobot=${game.activePlayer.isRobot}`,
+      )
+    }
+
+    const CoreUtil = await getCore()
+    const BoardUtil = await getBoard()
+    const matchStep = await getMatchStepToReadyMove()
+
+    const provider = this.buildProvider(game)
+    const request = await this.buildHintRequest(game)
+    // One-shot plan: getMoveHints validates the returned play against CORE's
+    // enumerated legal plays before it is trusted.
+    const hints = await provider.getMoveHints(request, 5)
+    const plan: MoveStep[] = hints[0]?.moves ?? []
+
+    let workingGame: any = game
+    let planIdx = 0
+    let guard = TURN_GUARD
+
+    while (guard-- > 0 && workingGame.stateKind === 'moving') {
+      const moves = (workingGame.activePlay?.moves ?? []) as any[]
+      // Larger die first so an ambiguous bear-off resolves to the larger die
+      // (CORE's must-use-larger-die rule), matching the GNU path's ordering.
+      const ready = moves
+        .filter((m) => m.stateKind === 'ready')
+        .sort((a, b) => (b.dieValue ?? 0) - (a.dieValue ?? 0))
+
+      // Refresh possibleMoves from the current board; stored ones go stale after
+      // each executed step.
+      for (const rm of ready) {
+        rm.possibleMoves = BoardUtil.getPossibleMoves(
+          workingGame.board,
+          workingGame.activePlay.player,
+          rm.dieValue,
+        )
+      }
+
+      const step = planIdx < plan.length ? plan[planIdx] : undefined
+      if (ready.length === 0 || !step) {
+        workingGame = CoreUtil.Game.checkAndCompleteTurn(workingGame)
+        break
+      }
+
+      const direction = (workingGame.activePlayer?.direction ??
+        'clockwise') as BackgammonMoveDirection
+      const match = matchStep(step, ready, direction, null)
+      if (!match.matched || !match.originId) {
+        throw new Error(
+          `[AI] NeuralAIProvider: neural plan step (from=${step.from}, to=${step.to}, ` +
+            `kind=${step.moveKind}) has no matching CORE legal move for position ` +
+            `${request.positionId}. Refusing to substitute a different move.`,
+        )
+      }
+
+      workingGame = CoreUtil.Game.executeAndRecalculate(
+        workingGame,
+        match.originId,
+        {
+          desiredDestinationId: match.desiredDestinationId ?? undefined,
+          expectedDieValue: match.matchedDie as BackgammonDieValue | undefined,
+        },
+      )
+      planIdx++
+    }
+
+    if (workingGame.stateKind === 'moving') {
+      workingGame = CoreUtil.Game.checkAndCompleteTurn(workingGame)
+    }
+    return workingGame as BackgammonGameRolling
+  }
+
+  /**
+   * Select the best single move from a play. Delegates to the shared heuristic
+   * selector (opening book / policy / strategic), identical to the GNU and
+   * Nodots providers -- move selection here is provider-agnostic.
+   */
+  async selectBestMove(
+    play: BackgammonPlayMoving,
+    _playerUserId?: string,
+  ): Promise<BackgammonMoveReady | undefined> {
+    const { selectBestMove } = await import('../moveSelection.js')
+    return selectBestMove(play)
+  }
+}


### PR DESCRIPTION
Refs nodots/backgammon#379

Adds the host-side `NeuralAIProvider` so the first-party Nodots neural engine is driven as a first-class plugin, exactly like the reference vendor. Pairs with backgammon-neural PR #12 (the /v1 service).

## What changed
- **`src/providers/NeuralAIProvider.ts` (new)** — implements CORE's `RobotAIProvider`:
  - Reaches the neural engine ONLY over HTTP through `HttpEngineProvider` (baseUrl from `NEURAL_ENGINE_URL`, engineId `nodots-neural`, API key ref `NEURAL_ENGINE_API_KEY`, optional HMAC). No in-process neural code; the engine stays a swappable plugin behind `@nodots/backgammon-engine-protocol`.
  - **legalMoveResolver wired to CORE enumeration**: `enumerateLegalPlays` composes `Board.getPossibleMoves` single-die steps into full legal plays via `Board.moveChecker` (both die orders, doubles, use-max-dice + higher-die), returned as `MoveHint[]`. `HttpEngineProvider` validates the engine's returned play against these (`findMatchingHint`) before it is trusted.
  - **No silent fallback** (CLAUDE.md): each executed step is re-matched to a CORE ready move via the exported `matchStepToReadyMove`; an unmatched step throws with diagnostics rather than substituting. Execution goes through `Game.executeAndRecalculate` / `Game.checkAndCompleteTurn`.
  - `selectBestMove` delegates to the shared heuristic selector (same as GNU/Nodots).
- **`src/index.ts`** — registers the provider under `nn-*` in `RobotAIRegistry` alongside the existing providers, and exports `NeuralAIProvider`. No existing routing/behavior changed.
- **`src/__tests__/neural-ai-provider.test.ts` (new)** — hermetic: a real in-process mock `/v1` server (no fetch mock) + mocked CORE. Proves a full turn is fetched over HTTP and executed via CORE in order; an illegal engine play throws (no fallback, nothing executed); a non-robot player is refused.

## Gates
- build/typecheck (`tsc -b`): clean
- test: **no regression** — failing-suite set identical to the ~8-suite baseline (8 failed / 3 skipped, all pre-existing GNU/native-addon + ts-jest ESM issues unrelated to this change). This branch ADDS a passing suite: 9 passed (was 8), 53 tests pass (was 50). Before: `8 failed, 3 skipped, 8 passed`; after: `8 failed, 3 skipped, 9 passed`.
- lint: my files add **0 errors** (only `any`/unused-arg warnings matching the codebase style). Pre-existing lint errors live in `HttpEngineProvider.ts` etc. (`no-undef` for `fetch`/`AbortController` — the eslint config lacks those globals) and are out of this cell's lane; `package.json`/config are forbidden paths.
- check:licenses: no such script in this package.

## Stayed in lane
Touched only `src/providers/**`, `src/__tests__/**`, `src/index.ts`. Did not touch `src/robotExecution.ts`, `package.json`, `tsconfig.json`, or CI.